### PR TITLE
Updated build to make api-client-build needed

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -73,11 +73,10 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          file_pattern: './public/build/ ./public/core-dll/'
           commit_message: Apply latest automatic api client updates
 
   lint:
-    needs: install
+    needs: api-client-build
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Removed file patterns for api-client-build

## Changes in this pull request
Resolves #

## Additional info
