### PR TITLE
introduce setNodeUpdateDataQualityScores to only update dataQuality scores that exist up to this point

### DIFF
--- a/assets/js/src/core/components/element-tree/element-tree-slice.ts
+++ b/assets/js/src/core/components/element-tree/element-tree-slice.ts
@@ -535,18 +535,43 @@ const slice = createSlice({
         }
       })
     },
-    setNodeAdditionalAttributes: (
+    setNodeUpdateDataQualityScores: (
       state,
       { payload }: PayloadAction<{
         nodeId: string
         elementType: ElementType
-        additionalAttributes: Record<string, any>
+        dataQuality: Array<{
+          name: string
+          title: string
+          mark: string
+          score: number
+          rules: Array<{
+            title: string
+            suggestion: string
+            valid: boolean
+          }>
+          lastUpdated: number
+          additionalAttributes: any[]
+        }>
       }>
     ) => {
       Object.keys(state).forEach(treeId => {
         if (state[treeId].nodes[payload.nodeId]?.treeNodeProps?.elementType === payload.elementType) {
           updateNodeState(state, treeId, payload.nodeId, node => {
             const metadataKey = camelCase(payload.elementType)
+            const currentAdditionalAttributes = node.treeNodeProps?.metaData?.[metadataKey]?.additionalAttributes
+            const currentDataQuality = currentAdditionalAttributes?.dataQuality ?? {}
+
+            const updatedDataQuality = { ...currentDataQuality }
+            payload.dataQuality.forEach(item => {
+              if (currentDataQuality[item.name] !== undefined) {
+                updatedDataQuality[item.name] = {
+                  mark: item.mark,
+                  score: item.score
+                }
+              }
+            })
+
             return {
               ...node,
               treeNodeProps: !isUndefined(node.treeNodeProps)
@@ -556,11 +581,10 @@ const slice = createSlice({
                       ...node.treeNodeProps.metaData,
                       [metadataKey]: {
                         ...node.treeNodeProps.metaData?.[metadataKey],
-                        additionalAttributes: merge(
-                          {},
-                          node.treeNodeProps.metaData?.[metadataKey]?.additionalAttributes,
-                          payload.additionalAttributes
-                        )
+                        additionalAttributes: {
+                          ...currentAdditionalAttributes,
+                          dataQuality: updatedDataQuality
+                        }
                       }
                     }
                   }
@@ -724,6 +748,24 @@ const slice = createSlice({
           }))
         }
       })
+    },
+    updateEntireNode: (
+      state,
+      { payload }: PayloadAction<{ nodeId: string, elementType: ElementType, updatedNode: Partial<TreeNode> }>
+    ) => {
+      Object.keys(state).forEach(treeId => {
+        if (state[treeId].nodes[payload.nodeId]?.treeNodeProps?.elementType === payload.elementType) {
+          updateNodeState(state, treeId, payload.nodeId, node => ({
+            ...node,
+            treeNodeProps: !isUndefined(node.treeNodeProps)
+              ? {
+                  ...node.treeNodeProps,
+                  ...payload.updatedNode
+                }
+              : undefined
+          }))
+        }
+      })
     }
   }
 })
@@ -732,7 +774,7 @@ export const treeSliceName = slice.name
 
 injectSliceWithState(slice)
 
-export const { setNodeLoading, setNodeLoadingInAllTree, setNodeExpanded, setNodeHasChildren, setNodePage, setNodeSearchTerm, setSelectedNodeIds, setNodeScrollTo, updateNodesByParentId, locateInTree, setFetchTriggered, setRootFetchTriggered, setNodeFetching, refreshNodeChildren, refreshTargetNode, refreshSourceNode, markNodeDeleting, renameNode, updateNodeType, setNodePublished, setNodeAdditionalAttributes, setRootNode, setDocumentNodeSiteStatus, setNodeLocked, refreshTreeByElementType, setDocumentNodeNavigationExclude } = slice.actions
+export const { setNodeLoading, setNodeLoadingInAllTree, setNodeExpanded, setNodeHasChildren, setNodePage, setNodeSearchTerm, setSelectedNodeIds, setNodeScrollTo, updateNodesByParentId, locateInTree, setFetchTriggered, setRootFetchTriggered, setNodeFetching, refreshNodeChildren, refreshTargetNode, refreshSourceNode, markNodeDeleting, renameNode, updateNodeType, setNodePublished, setNodeUpdateDataQualityScores, setRootNode, setDocumentNodeSiteStatus, setNodeLocked, refreshTreeByElementType, setDocumentNodeNavigationExclude, updateEntireNode } = slice.actions
 
 export const selectNodeState = createSelector(
   (state: RootState) => state.trees,

--- a/assets/js/src/core/components/element-tree/element-tree-slice.ts
+++ b/assets/js/src/core/components/element-tree/element-tree-slice.ts
@@ -748,24 +748,6 @@ const slice = createSlice({
           }))
         }
       })
-    },
-    updateEntireNode: (
-      state,
-      { payload }: PayloadAction<{ nodeId: string, elementType: ElementType, updatedNode: Partial<TreeNode> }>
-    ) => {
-      Object.keys(state).forEach(treeId => {
-        if (state[treeId].nodes[payload.nodeId]?.treeNodeProps?.elementType === payload.elementType) {
-          updateNodeState(state, treeId, payload.nodeId, node => ({
-            ...node,
-            treeNodeProps: !isUndefined(node.treeNodeProps)
-              ? {
-                  ...node.treeNodeProps,
-                  ...payload.updatedNode
-                }
-              : undefined
-          }))
-        }
-      })
     }
   }
 })
@@ -774,7 +756,7 @@ export const treeSliceName = slice.name
 
 injectSliceWithState(slice)
 
-export const { setNodeLoading, setNodeLoadingInAllTree, setNodeExpanded, setNodeHasChildren, setNodePage, setNodeSearchTerm, setSelectedNodeIds, setNodeScrollTo, updateNodesByParentId, locateInTree, setFetchTriggered, setRootFetchTriggered, setNodeFetching, refreshNodeChildren, refreshTargetNode, refreshSourceNode, markNodeDeleting, renameNode, updateNodeType, setNodePublished, setNodeUpdateDataQualityScores, setRootNode, setDocumentNodeSiteStatus, setNodeLocked, refreshTreeByElementType, setDocumentNodeNavigationExclude, updateEntireNode } = slice.actions
+export const { setNodeLoading, setNodeLoadingInAllTree, setNodeExpanded, setNodeHasChildren, setNodePage, setNodeSearchTerm, setSelectedNodeIds, setNodeScrollTo, updateNodesByParentId, locateInTree, setFetchTriggered, setRootFetchTriggered, setNodeFetching, refreshNodeChildren, refreshTargetNode, refreshSourceNode, markNodeDeleting, renameNode, updateNodeType, setNodePublished, setNodeUpdateDataQualityScores, setRootNode, setDocumentNodeSiteStatus, setNodeLocked, refreshTreeByElementType, setDocumentNodeNavigationExclude } = slice.actions
 
 export const selectNodeState = createSelector(
   (state: RootState) => state.trees,


### PR DESCRIPTION
## Changes in this pull request
Resolves #

## Additional info

This pull request updates the Redux slice for the element tree to improve how node data quality scores are managed and to add a new utility for updating entire nodes. The most important changes are grouped below:

**Data Quality Score Management:**

* Refactored the `setNodeAdditionalAttributes` reducer to `setNodeUpdateDataQualityScores`, changing its focus to updating data quality scores for nodes. The new implementation expects a `dataQuality` array, processes it, and updates only the relevant data quality fields in the node's metadata.
* Updated the way `additionalAttributes` are handled in the node metadata to specifically merge and update the `dataQuality` object, ensuring only the intended fields are changed.

**Node Update Utilities:**

* Added a new reducer, `updateEntireNode`, which allows updating arbitrary properties of a node's `treeNodeProps` by merging in a provided partial node object. This makes it easier to perform bulk or flexible updates to a node's properties.

**Action Exports:**

* Updated the exported actions to reflect the new and renamed reducers, replacing `setNodeAdditionalAttributes` with `setNodeUpdateDataQualityScores` and adding `updateEntireNode` to the exports.