### PR TITLE
[Widget Manager] Export WidgetManagerTabConfig type for SDK

### DIFF
--- a/assets/js/src/sdk/modules/widget-manager/index.ts
+++ b/assets/js/src/sdk/modules/widget-manager/index.ts
@@ -14,6 +14,7 @@ if (module.hot !== undefined) {
 
 export * from '@Pimcore/modules/widget-manager/hooks/use-widget-manager'
 export * from '@Pimcore/modules/widget-manager/services/widget-registry'
+export type { WidgetManagerTabConfig } from '@Pimcore/modules/widget-manager/widget-manager-slice'
 // Additional types
 export type { Widget } from '@Pimcore/modules/widget-manager/services/widget-registry'
 export type { ElementIcon } from '@Pimcore/modules/asset/asset-api-slice.gen'


### PR DESCRIPTION
## Changes in this pull request
- Export WidgetManagerTabConfig type in SDK so bundles (e.g. dashboards-bundle) can use it
