### PR TITLE
Update disclosure widget UX

### DIFF
--- a/assets/js/src/core/components/element-tree/expander/tree-expander.tsx
+++ b/assets/js/src/core/components/element-tree/expander/tree-expander.tsx
@@ -66,13 +66,13 @@ export const TreeExpander = ({ node, state }: TreeExpanderProps): React.JSX.Elem
                 ? (
                   <Icon
                     options={ { width: 16, height: 16 } }
-                    value="chevron-up"
+                    value="chevron-down"
                   />
                   )
                 : (
                   <Icon
                     options={ { width: 16, height: 16 } }
-                    value="chevron-down"
+                    value="chevron-right"
                   />
                   )
               }


### PR DESCRIPTION
## Changes in this pull request
Updated the tree expander disclosure widget to be `chevron-down` when expanded and `chevron-right` when closed.

## Additional info
Several different design standards suggest using right/down chevrons for disclosure widget expanders, including [ARIA-APG](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/), [Ant Design](https://ant.design/components/tree), and [Apple](https://developer.apple.com/design/human-interface-guidelines/disclosure-controls#Disclosure-triangles).
