### PR TITLE
fix: allow format toggle in rgba color picker

### DIFF
--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/types/dynamic-type-object-data-rgba-color.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/types/dynamic-type-object-data-rgba-color.tsx
@@ -46,8 +46,8 @@ export class DynamicTypeObjectDataRgbaColor extends DynamicTypeObjectDataAbstrac
       <ColorPicker
         allowClear
         className={ props.className }
+        defaultFormat={ 'hex' }
         disabled={ props.noteditable === true }
-        format={ 'hex' }
         inherited={ props.inherited }
         showText={ formatColorShowText }
         value={ props.value }


### PR DESCRIPTION
## Problem

In the data object editor for the `rgbaColor` data type, the format toggle button (HEX / RGB / HSB) inside the antd `<ColorPicker>` is rendered but cannot be activated — clicking it does nothing and the picker stays locked to HEX.

## Cause

`dynamic-type-object-data-rgba-color.tsx` passes `format={ 'hex' }` as a **controlled** prop without a corresponding `onFormatChange` handler. Antd's `<ColorPicker>` treats this as fully controlled and disables the format selector, because changes from the user would be discarded.

## Fix

Switch the prop from controlled `format` to **uncontrolled** `defaultFormat`. Behaviour is unchanged on first render (HEX), but the toggle now stays interactive and the user can switch to RGB/HSB.

```diff
       <ColorPicker
         allowClear
         className={ props.className }
+        defaultFormat={ 'hex' }
         disabled={ props.noteditable === true }
-        format={ 'hex' }
         inherited={ props.inherited }
         showText={ formatColorShowText }
         value={ props.value }
       />
```

## Reproduction

1. Create a class with an `rgbaColor` field, save an object with a value (e.g. `#2F7ECE`)
2. Open the editor → the `HEX ▾` selector inside the picker is visible but clicking the chevron has no effect
3. After this fix the dropdown opens and HEX/RGB/HSB can be switched

Tested against Pimcore 2026.1.x.