### PR TITLE
[Bug] Bricks should be saving class name and not id.

### DIFF
--- a/assets/js/src/core/modules/object-brick/components/object-brick-editor/object-brick-class-definitions-block.tsx
+++ b/assets/js/src/core/modules/object-brick/components/object-brick-editor/object-brick-class-definitions-block.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next'
 
 interface FieldnameSelectProps {
   blockIndex: number
+  classIdByName: Record<string, string>
   // Injected by NumberedFormItemControl — must be forwarded to inner <Select>
   value?: string | null
   onChange?: (value: string | null) => void
@@ -30,7 +31,7 @@ interface FieldnameSelectProps {
 // Per-row fieldname select: reads classname from the NumberedList's internal
 // state via operations.getValue (Form.useWatch reads the Ant Design form store
 // which does NOT contain values managed by NumberedList's own useState).
-const FieldnameSelect = ({ blockIndex, value, onChange }: FieldnameSelectProps): React.JSX.Element => {
+const FieldnameSelect = ({ blockIndex, classIdByName, value, onChange }: FieldnameSelectProps): React.JSX.Element => {
   const { t } = useTranslation()
   const { operations } = useNumberedList()
   const classname = operations.getValue(['classDefinitions', blockIndex, 'classname']) as string | undefined
@@ -43,9 +44,11 @@ const FieldnameSelect = ({ blockIndex, value, onChange }: FieldnameSelectProps):
     prevClassnameRef.current = classname
   }, [classname])
 
+  const classId = classname !== undefined ? classIdByName[classname] : undefined
+
   const { data, isFetching } = useClassDefinitionGetBricksUsagesQuery(
-    { id: classname! },
-    { skip: classname === undefined || classname === '' }
+    { id: classId! },
+    { skip: classId === undefined || classId === '' }
   )
 
   const options = useMemo(() => {
@@ -81,21 +84,21 @@ export const ObjectBrickClassDefinitionsBlock = (): React.JSX.Element => {
     if (classesData?.items === undefined) return []
     return classesData.items.map((item) => ({
       label: item.name,
-      value: item.id
+      value: item.name
     }))
   }, [classesData])
 
-  // Map class id -> name for the block item title
-  const classNameById = useMemo(() => {
+  // Map class name -> id so FieldnameSelect can call the bricks-usages API with the correct identifier
+  const classIdByName = useMemo(() => {
     const map: Record<string, string> = {}
-    classesData?.items?.forEach((item) => { map[item.id] = item.name })
+    classesData?.items?.forEach((item) => { map[item.name] = item.id })
     return map
   }, [classesData])
 
   return (
     <Form.Item name="classDefinitions">
       <Block
-        getItemTitle={ (item) => (item?.classname !== undefined ? classNameById[item.classname] ?? item.classname : t('object-brick.class-definitions-block.new-entry')) }
+        getItemTitle={ (item) => (item?.classname !== undefined ? item.classname : t('object-brick.class-definitions-block.new-entry')) }
         title={ t('object-brick.class-definitions-block.title') }
       >
         { ({ blockIndex }) => (
@@ -116,7 +119,7 @@ export const ObjectBrickClassDefinitionsBlock = (): React.JSX.Element => {
               label={ t('object-brick.class-definitions-block.fieldname') }
               name="fieldname"
             >
-              <FieldnameSelect blockIndex={ blockIndex } />
+              <FieldnameSelect blockIndex={ blockIndex } classIdByName={ classIdByName } />
             </Form.Item>
           </FormKit.Panel>
         ) }


### PR DESCRIPTION
This changes the logic to save the class using name instead of class id, so its the same behavior as the legacy admin. This also fixes multiple other small errors / bugs when working within the brick editor in studio.

You can reproduce this in the demo by:
1. Opening up a brick
2. Attempt to save the brick to a class with a mismatch class id and name
3. Hit save

<img width="2226" height="92" alt="image" src="https://github.com/user-attachments/assets/fca477ad-cb1e-473d-9058-91e44d334e99" />
<img width="1612" height="1488" alt="image" src="https://github.com/user-attachments/assets/b209e6d5-8b81-4a78-8781-46348463805f" />



