### PR TITLE
Further performance enhancements for background loader

### DIFF
--- a/assets/js/src/core/components/background/background.styles.ts
+++ b/assets/js/src/core/components/background/background.styles.ts
@@ -92,8 +92,8 @@ export const useStyle = createStyles(({ css }, { phase, backgroundShade }: Style
 
       .background-figure {
         position: absolute;
-        will-change: transform;
         flex-shrink: 0;
+        filter: blur(90px);
 
         ${isOrbiting
           ? css`
@@ -198,13 +198,6 @@ export const useStyle = createStyles(({ css }, { phase, backgroundShade }: Style
         }
       }
     `,
-    backdropBlur: css`
-      position: absolute;
-      inset: 0;
-      backdrop-filter: blur(90px);
-      -webkit-backdrop-filter: blur(90px);
-      pointer-events: none;
-    `,
     logoImage: css`      position: absolute;
       top: 50%;
       left: 50%;
@@ -223,10 +216,9 @@ export const useStyle = createStyles(({ css }, { phase, backgroundShade }: Style
       background: rgba(253, 255, 255, 0.35);
       filter: blur(75px);
       pointer-events: none;
-      will-change: transform;
 
       ${isOrbiting
-        ? css`animation: ${logoOrbitCW} 3s linear infinite;`
+        ? css`animation: ${logoOrbitCW} 3s linear infinite; will-change: transform;`
         : css`transform: translate(-50%, -50%) rotate(0deg) translateX(80px);`
       }
 
@@ -245,10 +237,9 @@ export const useStyle = createStyles(({ css }, { phase, backgroundShade }: Style
       background: rgba(253, 255, 255, 0.35);
       filter: blur(75px);
       pointer-events: none;
-      will-change: transform;
 
       ${isOrbiting
-        ? css`animation: ${logoOrbitCCW} 4s linear infinite;`
+        ? css`animation: ${logoOrbitCCW} 4s linear infinite; will-change: transform;`
         : css`transform: translate(-50%, -50%) rotate(180deg) translateX(80px);`
       }
 

--- a/assets/js/src/core/components/background/background.tsx
+++ b/assets/js/src/core/components/background/background.tsx
@@ -43,7 +43,6 @@ const Background = ({ phase = 'idle' }: BackgroundProps): React.JSX.Element => {
       <div className='background-figure background-figure--bottom-left'></div>
       <div className='background-figure background-figure--bottom-right'></div>
       <div className='background-figure background-figure--top-left'></div>
-      <div className={ styles.backdropBlur } />
       <div className={ styles.logoOrbitCW } />
       <div className={ styles.logoOrbitCCW } />
       <img

--- a/templates/default/_preloader.html.twig
+++ b/templates/default/_preloader.html.twig
@@ -23,7 +23,7 @@
         top: 50%;
         left: 50%;
         opacity: 0.7;
-        will-change: transform;
+        filter: blur(90px);
     }
 
     #app-preloader .background-figure--top-left {
@@ -88,14 +88,6 @@
         opacity: 1;
     }
 
-    #app-preloader .backdrop-blur {
-        position: absolute;
-        inset: 0;
-        backdrop-filter: blur(90px);
-        -webkit-backdrop-filter: blur(90px);
-        pointer-events: none;
-    }
-
     #app-preloader .logo-orbit {
         position: absolute;
         top: 50%;
@@ -106,7 +98,6 @@
         background: rgba(253, 255, 255, 0.35);
         filter: blur(75px);
         pointer-events: none;
-        will-change: transform;
     }
     #app-preloader .logo-orbit--cw  { animation: pimcore-logo-orbit-cw  3s linear infinite; }
     #app-preloader .logo-orbit--ccw { animation: pimcore-logo-orbit-ccw 4s linear infinite; }


### PR DESCRIPTION
While the fixes from https://github.com/pimcore/studio-ui-bundle/pull/3616/ do improve performance and reduce peak/idle GPU utilization, we're still noticing sluggish UI - mostly choppy tab animations and laggy on hover highlighting in the element trees. When hardware acceleration is turned off (to emulate client devices with no dedicated GPU), the app is still unusable.

Suspected Cause:
- The `backdrop-filter: blur(90px);` in the `background.styles.ts` seems to be the main culprit. When it's removed, the UI runs buttery smooth and the GPU idles at ~0%.

Solution:
- Remove the `backdropBlur` element in favour of an increased `filter: blur(90px)` on the background-figure elements themselves. The animation and background look virtually identical.
- Additionally, the `will-change: transform` only really needs to be on the background figures while they are orbiting - once the app is loaded they won't change anymore and don't need to be tracked. This was actually causing some extra performance issues with no GPU. [MDN actually recommends against](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/will-change) using `will-change` if possible, so I think restricting it to only during the orbit animation is good enough.