### PR TITLE
Bug fix: infinite render loop for objects with manyToManyObjectRelation fields

### DIFF
--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/many-to-many-object-relation/hooks/use-data-object-grids.ts
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/many-to-many-object-relation/hooks/use-data-object-grids.ts
@@ -8,6 +8,7 @@
  *  @license    Pimcore Open Core License (POCL)
  */
 
+import { useMemo } from 'react'
 import { map, filter, isEmpty } from 'lodash'
 import {
   type DataObjectGetGridApiResponse,
@@ -64,7 +65,7 @@ export const useDataObjectGrids = ({ classIds, convertClassName, columns, applyF
   })
 
   const isLoading = queries.some(q => q.isLoading || q.isFetching)
-  const data = queries.flatMap(q => q.data?.items ?? [])
+  const data = useMemo(() => queries.flatMap(q => q.data?.items ?? []), queries.map(q => q.data))
   const refetchAll = (): void => { queries.forEach(q => { void q.refetch() }) }
 
   return { isLoading, data, refetchAll }


### PR DESCRIPTION
Whenever a data object with a `manyToManyObjectRelation` field is opened in studio ui the UI gets sluggish and the browser starts continuously firing the following console error:
```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
ManyToManyObjectRelationInner@http://localhost:3030/static/js/async/__federation_expose_app.js:111615:68
DynamicTypeRegistryProvider@http://localhost:3030/static/js/async/__federation_expose_app.js:125673:36
ManyToManyObjectRelation
```

Solution:
- There seems to be an infinite loop, memoizing data in `use-data-object-grids.ts` seems to fix it.