### PR TITLE
Feature/standardize export sheet name

### DIFF
--- a/assets/js/src/core/modules/element/export-api-slice.gen.ts
+++ b/assets/js/src/core/modules/element/export-api-slice.gen.ts
@@ -192,6 +192,7 @@ export type ExportXlsxApiArg = {
                 | "string"
                 | "bool"
                 | "items_to_restore";
+            sheetName?: string;
         };
         elementType?: "data-object" | "object" | "asset" | "document";
         classId?: string | null;
@@ -234,6 +235,7 @@ export type ExportXlsxFolderApiArg = {
                 | "string"
                 | "bool"
                 | "items_to_restore";
+            sheetName?: string;
         };
         elementType?: "data-object" | "object" | "asset" | "document";
         classId?: string | null;

--- a/assets/js/src/core/modules/element/listing/batch-actions/xlsx-modal/create-xlsx-form/create-xlsx-form.tsx
+++ b/assets/js/src/core/modules/element/listing/batch-actions/xlsx-modal/create-xlsx-form/create-xlsx-form.tsx
@@ -12,9 +12,11 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Form, type FormProps } from '@Pimcore/components/form/form'
 import { Select } from '@Pimcore/components/select/select'
+import { Input } from '@Pimcore/components/input/input'
 
 export interface XLSXFormValues {
   header: 'name' | 'title' | 'no_header'
+  sheetName: string
 }
 
 export interface CreateXLSXFormProps extends FormProps {}
@@ -41,6 +43,14 @@ export const CreateXLSXForm = ({ ...props }: CreateXLSXFormProps): React.JSX.Ele
             ]
           }
         />
+      </Form.Item>
+
+      <Form.Item
+        label={ t('export-xlsx-form.form-field.sheet-name') }
+        name={ 'sheetName' }
+        rules={ [{ required: true, message: t('form.validation.required') }] }
+      >
+        <Input />
       </Form.Item>
     </Form>
   )

--- a/assets/js/src/core/modules/element/listing/batch-actions/xlsx-modal/xlsx-modal.tsx
+++ b/assets/js/src/core/modules/element/listing/batch-actions/xlsx-modal/xlsx-modal.tsx
@@ -151,7 +151,7 @@ export const XlsxModal = (props: XlsxModalProps): React.JSX.Element => {
           config: {
             header,
             sheetName
-          } as any,
+          },
           filters: {
             ...filters
           },
@@ -171,7 +171,7 @@ export const XlsxModal = (props: XlsxModalProps): React.JSX.Element => {
           config: {
             header,
             sheetName
-          } as any,
+          },
           ...(!isNil(selectedClassDefinition?.id) && { classId: selectedClassDefinition.id })
         }
       })

--- a/assets/js/src/core/modules/element/listing/batch-actions/xlsx-modal/xlsx-modal.tsx
+++ b/assets/js/src/core/modules/element/listing/batch-actions/xlsx-modal/xlsx-modal.tsx
@@ -49,7 +49,8 @@ export const XlsxModal = (props: XlsxModalProps): React.JSX.Element => {
   const classDefinitionSelection = useClassDefinitionSelection(true)
   const selectedClassDefinition = classDefinitionSelection?.selectedClassDefinition
   const initialFormValues: XLSXFormValues = {
-    header: 'name'
+    header: 'name',
+    sheetName: 'Sheet1'
   }
   const { t } = useTranslation()
 
@@ -110,13 +111,13 @@ export const XlsxModal = (props: XlsxModalProps): React.JSX.Element => {
 
   function onFinish (values: XLSXFormValues): void {
     const isFolderExport = numberedSelectedRows.length === 0
-    const job = new XlsxDownloadJob({ action: async () => await getDownloadAction(values.header), isFolderExport })
+    const job = new XlsxDownloadJob({ action: async () => await getDownloadAction(values.header, values.sheetName), isFolderExport })
     void executionEngine.runJob(job)
 
     props.setOpen(false)
   }
 
-  async function getDownloadAction (header: XLSXFormValues['header']): Promise<number> {
+  async function getDownloadAction (header: XLSXFormValues['header'], sheetName: XLSXFormValues['sheetName']): Promise<number> {
     const extractedColumnsFromColumnArg: GridColumnRequest[] = []
     const columns = getArgs()?.body?.columns ?? []
 
@@ -148,8 +149,9 @@ export const XlsxModal = (props: XlsxModalProps): React.JSX.Element => {
           elementType,
           columns: extractedColumnsFromColumnArg,
           config: {
-            header
-          },
+            header,
+            sheetName
+          } as any,
           filters: {
             ...filters
           },
@@ -167,8 +169,9 @@ export const XlsxModal = (props: XlsxModalProps): React.JSX.Element => {
           elementType,
           columns: extractedColumnsFromColumnArg,
           config: {
-            header
-          },
+            header,
+            sheetName
+          } as any,
           ...(!isNil(selectedClassDefinition?.id) && { classId: selectedClassDefinition.id })
         }
       })

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -991,7 +991,7 @@ lazy-loading: Lazy Loading
 disallow-add-remove: Disallow Add / Remove
 disallow-reorder: Disallow Reorder
 css-style: CSS Style
-css-style-tooltip: "Inline CSS applied to the body, e.g. \"float: left; margin: 10px;\". Invalid declarations are ignored."
+css-style-tooltip: 'Inline CSS applied to the body, e.g. "float: left; margin: 10px;". Invalid declarations are ignored.'
 collapsible: Collapsible
 collapsed: Initially Collapsed
 border: Border
@@ -1099,6 +1099,7 @@ export-xlsx-form.form-field.header: Header
 export-xlsx-form.form-field.header.option.name: System key
 export-xlsx-form.form-field.header.option.title: Label
 export-xlsx-form.form-field.header.option.no-header: No header
+export-xlsx-form.form-field.sheet-name: Sheet name
 form.validation.required: This field is required
 form.validation.max-length: The maximum length for this field is {{max}} characters
 form.validation.min: The minimum value is {{min}}
@@ -1908,18 +1909,18 @@ classification-store.tabs.groups: Groups
 classification-store.tabs.keys: Keys
 classification-store.add-store: Add store
 classification-store.rename-store: Rename store
-classification-store.delete-store: "Delete store \"{{storeName}}\"?"
+classification-store.delete-store: 'Delete store "{{storeName}}"?'
 classification-store.add-group: Add group
 classification-store.rename-group: Rename group
-classification-store.delete-group: "Delete group \"{{groupName}}\"?"
+classification-store.delete-group: 'Delete group "{{groupName}}"?'
 classification-store.add-collection: Add collection
 classification-store.rename-collection: Rename collection
-classification-store.delete-collection: "Delete collection \"{{collectionName}}\"?"
+classification-store.delete-collection: 'Delete collection "{{collectionName}}"?'
 classification-store.add-key: Add key
 classification-store.rename-key: Rename key
-classification-store.delete-key: "Delete key \"{{keyName}}\"?"
-classification-store.delete-key-relation: "Remove key \"{{keyName}}\" from this group?"
-classification-store.delete-group-relation: "Remove group \"{{groupName}}\" from this collection?"
+classification-store.delete-key: 'Delete key "{{keyName}}"?'
+classification-store.delete-key-relation: 'Remove key "{{keyName}}" from this group?'
+classification-store.delete-group-relation: 'Remove group "{{groupName}}" from this collection?'
 classification-store.edit-definition: Edit definition
 classification-store.edit-key-definition: "Edit key definition: {{keyName}}"
 classification-store.columns.id: ID


### PR DESCRIPTION
Companion to: https://github.com/pimcore/studio-backend-bundle/pull/1867

This pull request adds support for specifying a custom sheet name when exporting data to XLSX files and updates related UI and backend logic. It also includes minor improvements to translation strings for consistency.

**XLSX Export Enhancements:**

* Added a new `sheetName` field to the XLSX export form, allowing users to specify the name of the sheet in the exported file (`create-xlsx-form.tsx`, `XLSXFormValues`) [[1]](diffhunk://#diff-dec85045432fd12d267f28dc18825ffcf6ac07d78a82e3b57fc9ab8411bfe205R15-R19) [[2]](diffhunk://#diff-dec85045432fd12d267f28dc18825ffcf6ac07d78a82e3b57fc9ab8411bfe205R47-R54).
* Updated the XLSX modal logic to initialize the `sheetName` field with a default value (`Sheet1`) and to pass this value through the export job and backend request (`xlsx-modal.tsx`) [[1]](diffhunk://#diff-bf98af585785c863268b39a4339b7b6eaa496da9becebf61a387ff47d9b8b07dL52-R53) [[2]](diffhunk://#diff-bf98af585785c863268b39a4339b7b6eaa496da9becebf61a387ff47d9b8b07dL113-R120) [[3]](diffhunk://#diff-bf98af585785c863268b39a4339b7b6eaa496da9becebf61a387ff47d9b8b07dL151-R154) [[4]](diffhunk://#diff-bf98af585785c863268b39a4339b7b6eaa496da9becebf61a387ff47d9b8b07dL170-R174).
* Added a translation key for the new sheet name field label (`studio.en.yaml`).

**Translation and Formatting Improvements:**

* Standardized the use of single quotes for YAML string values containing double quotes for better consistency and to avoid parsing issues (`studio.en.yaml`) [[1]](diffhunk://#diff-6c9f9f77edb1e43229fb2c23bf06c513915c2f61c6e31b70c95e43d624e8bbbdL990-R990) [[2]](diffhunk://#diff-6c9f9f77edb1e43229fb2c23bf06c513915c2f61c6e31b70c95e43d624e8bbbdL1908-R1920).## Changes in this pull request
