### PR TITLE
CI: trigger frontend build on pushes to N.x version branches

### DIFF
--- a/.github/workflows/frontend-build-pr.yaml
+++ b/.github/workflows/frontend-build-pr.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
       - "feature-*"
       - "nightly"
       # TEMP (remove before merge): regenerate build-dist/build-<id>.zip on every push to


### PR DESCRIPTION
## Summary

Add `[0-9]+.x` to `push.branches` in [.github/workflows/frontend-build-pr.yaml](.github/workflows/frontend-build-pr.yaml) so `2026.x` runs the frontend build on every push — same as `2025.4` and `2026.2` already do.

The pipeline rebuilds and repackages on every push, and [`package-build.cjs`](assets/bundler/package-build.cjs#L117-L122) sweeps any stray `build-dist/build-*.zip` as a side effect. That makes the "two archives after a bad merge" state self-heal. Today it only self-heals on `[0-9]+.[0-9]+` branches; this extends it to `[0-9]+.x`.
