### PR TITLE
CI: pin npm to 11 for publish (works around npm@12 sigstore bug)

### DIFF
--- a/.github/workflows/shared-npm-publish.yaml
+++ b/.github/workflows/shared-npm-publish.yaml
@@ -85,4 +85,7 @@ jobs:
 
       - name: Publish package to npm with OIDC
         working-directory: ./assets
-        run: npx npm@latest publish --tag ${{ inputs.tag }} --access public
+        # Pin to npm 11: npm@12 (currently `npm@latest`) fails at publish time with
+        # "Cannot find module 'sigstore'" (broken sigstore dep in libnpmpublish/provenance).
+        # Revisit once npm upstream resolves the sigstore packaging issue.
+        run: npx npm@11 publish --tag ${{ inputs.tag }} --access public


### PR DESCRIPTION
## Summary

Pins npm to `11` in [`.github/workflows/shared-npm-publish.yaml`](.github/workflows/shared-npm-publish.yaml). `npm@latest` currently resolves to `npm@12.0.0`, which fails at publish with `Cannot find module 'sigstore'` — this blocks every canary publish.

## The failure

Run [#550](https://github.com/pimcore/studio-ui-bundle/actions/runs/29090079463) (manual dispatch, `2026.x @ c3c89622`):

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error Require stack:
npm error - .../npm/node_modules/libnpmpublish/lib/provenance.js
```

Upstream issue: `libnpmpublish` requires `sigstore` for OIDC provenance but the module is missing from `npm@12`'s dependency tree.

## Fix

```diff
-        run: npx npm@latest publish --tag ${{ inputs.tag }} --access public
+        run: npx npm@11 publish --tag ${{ inputs.tag }} --access public
```

Minimal and reversible — revert the pin once npm upstream ships a fix.

## Test plan

- [ ] After merge and forward-merge to `2026.x`: dispatch `Frontend build and publish` and confirm `canary-publish / publish` reaches `npm publish` without the `sigstore` error, producing a new `1.0.0-canary.*` on npm.