### PR TITLE
[Batch Delete] - add translations

### DIFF
--- a/translations/studio.de.yaml
+++ b/translations/studio.de.yaml
@@ -1196,7 +1196,8 @@ element.delete.batch.title: Elemente löschen
 element.delete.batch.note: 'Bitte beachten: Diese Elemente werden dauerhaft gelöscht und können nicht wiederhergestellt werden.'
 element.delete.batch.question_one: 'Möchten Sie dieses Element wirklich löschen?'
 element.delete.batch.question_other: 'Möchten Sie wirklich diese {{count}} Elemente löschen?'
-element.delete.batch.ok: Endgültig löschen
+element.delete.batch.ok: Löschen
+element.delete.batch.ok.permanent: Endgültig löschen
 element.delete.batch.show-paths: Elemente anzeigen
 element.delete.batch.dependencies-warning: 'Es könnte Abhängigkeiten geben, trotzdem löschen?'
 element.open: Öffnen

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -1206,7 +1206,8 @@ element.delete.batch.title: Delete items
 element.delete.batch.note: 'Please note: These items will be permanently deleted and can not be restored.'
 element.delete.batch.question_one: 'Do you really want to delete this item?'
 element.delete.batch.question_other: 'Do you really want to delete these {{count}} items?'
-element.delete.batch.ok: Delete permanently
+element.delete.batch.ok: Delete
+element.delete.batch.ok.permanent: Delete permanently
 element.delete.batch.show-paths: Show items
 element.delete.batch.dependencies-warning: 'There may be dependencies, delete anyway?'
 element.open: Open

--- a/translations/studio.es.yaml
+++ b/translations/studio.es.yaml
@@ -1196,7 +1196,8 @@ element.delete.batch.title: Eliminar elementos
 element.delete.batch.note: 'Tenga en cuenta: Estos elementos se eliminarán permanentemente y no se podrán restaurar.'
 element.delete.batch.question_one: '¿Realmente desea eliminar este elemento?'
 element.delete.batch.question_other: '¿Realmente desea eliminar estos {{count}} elementos?'
-element.delete.batch.ok: Eliminar permanentemente
+element.delete.batch.ok: Eliminar
+element.delete.batch.ok.permanent: Eliminar permanentemente
 element.delete.batch.show-paths: Mostrar elementos
 element.delete.batch.dependencies-warning: 'Puede haber dependencias, ¿eliminar de todas formas?'
 element.open: Abrir

--- a/translations/studio.fr.yaml
+++ b/translations/studio.fr.yaml
@@ -1196,7 +1196,8 @@ element.delete.batch.title: Supprimer des éléments
 element.delete.batch.note: 'Remarque : Ces éléments seront supprimés définitivement et ne pourront pas être restaurés.'
 element.delete.batch.question_one: 'Voulez-vous vraiment supprimer cet élément ?'
 element.delete.batch.question_other: 'Voulez-vous vraiment supprimer ces {{count}} éléments ?'
-element.delete.batch.ok: Supprimer définitivement
+element.delete.batch.ok: Supprimer
+element.delete.batch.ok.permanent: Supprimer définitivement
 element.delete.batch.show-paths: Afficher les éléments
 element.delete.batch.dependencies-warning: 'Il peut exister des dépendances, supprimer quand même ?'
 element.open: Ouvrir

--- a/translations/studio.it.yaml
+++ b/translations/studio.it.yaml
@@ -1196,7 +1196,8 @@ element.delete.batch.title: Elimina elementi
 element.delete.batch.note: 'Nota: Questi elementi verranno eliminati definitivamente e non potranno essere ripristinati.'
 element.delete.batch.question_one: 'Vuoi davvero eliminare questo elemento?'
 element.delete.batch.question_other: 'Vuoi davvero eliminare questi {{count}} elementi?'
-element.delete.batch.ok: Elimina definitivamente
+element.delete.batch.ok: Elimina
+element.delete.batch.ok.permanent: Elimina definitivamente
 element.delete.batch.show-paths: Mostra elementi
 element.delete.batch.dependencies-warning: 'Potrebbero esserci dipendenze, eliminare comunque?'
 element.open: Apri

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -1196,7 +1196,8 @@ element.delete.batch.title: Slett elementer
 element.delete.batch.note: 'Merk: Disse elementene vil bli slettet permanent og kan ikke gjenopprettes.'
 element.delete.batch.question_one: 'Vil du virkelig slette dette elementet?'
 element.delete.batch.question_other: 'Vil du virkelig slette disse {{count}} elementene?'
-element.delete.batch.ok: Slett permanent
+element.delete.batch.ok: Slett
+element.delete.batch.ok.permanent: Slett permanent
 element.delete.batch.show-paths: Vis elementer
 element.delete.batch.dependencies-warning: 'Det kan finnes avhengigheter, slett likevel?'
 element.open: Åpne

--- a/translations/studio.sv.yaml
+++ b/translations/studio.sv.yaml
@@ -1196,7 +1196,8 @@ element.delete.batch.title: Ta bort element
 element.delete.batch.note: 'Obs: Dessa element kommer att tas bort permanent och kan inte återställas.'
 element.delete.batch.question_one: 'Vill du verkligen ta bort det här elementet?'
 element.delete.batch.question_other: 'Vill du verkligen ta bort dessa {{count}} element?'
-element.delete.batch.ok: Ta bort permanent
+element.delete.batch.ok: Ta bort
+element.delete.batch.ok.permanent: Ta bort permanent
 element.delete.batch.show-paths: Visa element
 element.delete.batch.dependencies-warning: 'Det kan finnas beroenden, ta bort ändå?'
 element.open: Öppna


### PR DESCRIPTION


The batch delete confirm dialog reads its OK label from element.delete.batch.ok (non-permanent) / element.delete.batch.ok.permanent (permanent), mirroring the single-item/folder delete flow. The translations were wrong: .ok held the permanent wording ("Delete permanently") and .ok.permanent did not exist in any locale, so recoverable batch deletes always showed the permanent label.

Set .ok to the recycle-bin wording (from the folder.ok key) and add .ok.permanent with the permanent wording across all locales.

## Changes in this pull request
Resolves #

## Additional info
