### PR TITLE
[Studio UI] Fix tree action translation casing and wording

### DIFF
--- a/translations/studio.de.yaml
+++ b/translations/studio.de.yaml
@@ -1302,7 +1302,7 @@ tree.actions.paste: Einfügen
 tree.actions.delete: Löschen
 tree.actions.add-user: Benutzer hinzufügen
 tree.actions.clone-user: Benutzer klonen
-tree.actions.remove-user: Benutzer entfernen
+tree.actions.remove-user: Benutzer löschen
 tree.actions.folder: Ordner
 tree.actions.user: Benutzer
 tree.actions.add-folder: Neuer Ordner
@@ -1312,7 +1312,7 @@ tree.actions.rename-tag: Umbenennen
 tree.actions.role: Rolle
 tree.actions.add-role: Rolle hinzufügen
 tree.actions.clone-role: Rolle klonen
-tree.actions.remove-role: Rolle entfernen
+tree.actions.remove-role: Rolle löschen
 tree.actions.remove-folder: Ordner entfernen
 tag-configuration.new: Neu
 tag-configuration.new-tag: Neuer Tag

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -1311,8 +1311,8 @@ tree.actions.copy: Copy
 tree.actions.paste: Paste
 tree.actions.delete: Delete
 tree.actions.add-user: Add User
-tree.actions.clone-user: Clone User
-tree.actions.remove-user: Remove User
+tree.actions.clone-user: Clone user
+tree.actions.remove-user: Delete user
 tree.actions.folder: Folder
 tree.actions.user: User
 tree.actions.add-folder: New Folder
@@ -1321,8 +1321,8 @@ tree.actions.delete-tag: Delete
 tree.actions.rename-tag: Rename
 tree.actions.role: Role
 tree.actions.add-role: Add Role
-tree.actions.clone-role: Clone Role
-tree.actions.remove-role: Remove Role
+tree.actions.clone-role: Clone role
+tree.actions.remove-role: Delete role
 tree.actions.remove-folder: Remove Folder
 tag-configuration.new: New
 tag-configuration.new-tag: New Tag

--- a/translations/studio.it.yaml
+++ b/translations/studio.it.yaml
@@ -1302,7 +1302,7 @@ tree.actions.paste: Incolla
 tree.actions.delete: Elimina
 tree.actions.add-user: Aggiungi utente
 tree.actions.clone-user: Clona utente
-tree.actions.remove-user: Rimuovi utente
+tree.actions.remove-user: Elimina utente
 tree.actions.folder: Cartella
 tree.actions.user: Utente
 tree.actions.add-folder: Nuova cartella
@@ -1312,7 +1312,7 @@ tree.actions.rename-tag: Rinomina
 tree.actions.role: Ruolo
 tree.actions.add-role: Aggiungi ruolo
 tree.actions.clone-role: Clona ruolo
-tree.actions.remove-role: Rimuovi ruolo
+tree.actions.remove-role: Elimina ruolo
 tree.actions.remove-folder: Rimuovi cartella
 tag-configuration.new: Nuovo
 tag-configuration.new-tag: Nuovo tag

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -1302,7 +1302,7 @@ tree.actions.paste: Lim inn
 tree.actions.delete: Slett
 tree.actions.add-user: Legg til bruker
 tree.actions.clone-user: Klon bruker
-tree.actions.remove-user: Fjern bruker
+tree.actions.remove-user: Slett bruker
 tree.actions.folder: Mappe
 tree.actions.user: Bruker
 tree.actions.add-folder: Ny mappe
@@ -1312,7 +1312,7 @@ tree.actions.rename-tag: Gi nytt navn
 tree.actions.role: Rolle
 tree.actions.add-role: Legg til rolle
 tree.actions.clone-role: Klon rolle
-tree.actions.remove-role: Fjern rolle
+tree.actions.remove-role: Slett rolle
 tree.actions.remove-folder: Fjern mappe
 tag-configuration.new: Ny
 tag-configuration.new-tag: Ny tagg


### PR DESCRIPTION
## Summary
- Lowercase second word in clone actions (`Clone user`, `Clone role`) for consistent sentence-case in English
- Use "Delete" instead of "Remove" for user/role removal actions across all locales to match the convention used in `tree.actions.delete`

| Language | `remove-user` | `remove-role` | Changed? |
|----------|--------------|--------------|----------|
| en | Delete user | Delete role | Yes |
| de | Benutzer löschen | Rolle löschen | Yes |
| it | Elimina utente | Elimina ruolo | Yes |
| no | Slett bruker | Slett rolle | Yes |
| fr | Supprimer l'utilisateur | Supprimer le rôle | No — already correct |
| es | Eliminar usuario | Eliminar rol | No — already correct |
| sv | Ta bort användare | Ta bort roll | No — already correct |

Extracted from #3882 per reviewer feedback — these translation changes are unrelated to the search modal scope.

## Test plan
- [ ] Verify user management tree context menu shows correct labels
- [ ] Verify role management tree context menu shows correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)