### PR TITLE
[Element Editor] Render element validation errors as a list without the error. prefix

### DIFF
--- a/assets/js/src/core/modules/app/error-handler/components/api-error-view-ui.tsx
+++ b/assets/js/src/core/modules/app/error-handler/components/api-error-view-ui.tsx
@@ -14,6 +14,8 @@ import { isString, isUndefined } from 'lodash'
 import { type IErrorGetContent } from '@Pimcore/modules/app/error-handler/types'
 import { DEFAULT_ERROR_CONTENT } from '@Pimcore/modules/app/error-handler/classes/api-error'
 import { SanitizeHtml } from '@Pimcore/components/sanitize-html/sanitize-html'
+import { ErrorKeyTypes } from '@Pimcore/modules/app/error-handler/constants/errorTypes'
+import { formatValidationErrorHtml } from '@Pimcore/modules/app/error-handler/utils/format-validation-error'
 
 interface IApiErrorViewUIProps {
   errorContent: IErrorGetContent['data']
@@ -21,6 +23,17 @@ interface IApiErrorViewUIProps {
 
 export const ApiErrorViewUI = ({ errorContent }: IApiErrorViewUIProps): React.JSX.Element => {
   const { t } = useTranslation()
+
+  // Element validation: errorKey carries the human-readable, server-combined
+  // violation text (one per line), NOT an i18n key — render it directly as a
+  // list, without the `error.` prefix that t() would add.
+  if (
+    !isString(errorContent) &&
+    !isUndefined(errorContent?.errorKey) &&
+    errorContent?.title === ErrorKeyTypes.ELEMENT_VALIDATION_FAILED
+  ) {
+    return <SanitizeHtml html={ formatValidationErrorHtml(String(errorContent.errorKey)) } />
+  }
 
   const getErrorKeyValue = (): string => {
     if (!isString(errorContent) && !isUndefined(errorContent?.errorKey)) {

--- a/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.test.ts
+++ b/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.test.ts
@@ -33,4 +33,18 @@ describe('formatValidationErrorHtml', () => {
   it('returns an empty string for an empty message', () => {
     expect(formatValidationErrorHtml('')).toBe('')
   })
+
+  it('escapes HTML-like text in a single violation so it renders literally', () => {
+    expect(formatValidationErrorHtml('<img src=x onerror=alert(1)>'))
+      .toBe('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('escapes each violation so injected markup cannot add list items', () => {
+    const message = 'First <b>x</b>\n</li><li>Injected'
+    // Only the two wrapper <li> elements are real markup; the injected
+    // </li><li> is escaped, so it cannot forge a third list item.
+    expect(formatValidationErrorHtml(message)).toBe(
+      '<ul><li>First &lt;b&gt;x&lt;/b&gt;</li><li>&lt;/li&gt;&lt;li&gt;Injected</li></ul>'
+    )
+  })
 })

--- a/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.test.ts
+++ b/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+import { formatValidationErrorHtml } from './format-validation-error'
+
+describe('formatValidationErrorHtml', () => {
+  it('renders a single violation as a plain line (no list)', () => {
+    expect(formatValidationErrorHtml('Die Beschreibung darf nicht leer sein.'))
+      .toBe('Die Beschreibung darf nicht leer sein.')
+  })
+
+  it('renders multiple newline-separated violations as a list', () => {
+    const message =
+      'Für den Button muss ein Text angegeben werden.\n' +
+      'Link 1: Es muss ein Text angegeben werden.'
+    expect(formatValidationErrorHtml(message)).toBe(
+      '<ul><li>Für den Button muss ein Text angegeben werden.</li>' +
+        '<li>Link 1: Es muss ein Text angegeben werden.</li></ul>'
+    )
+  })
+
+  it('ignores blank lines and surrounding whitespace', () => {
+    expect(formatValidationErrorHtml('\n A \n\n B \n')).toBe('<ul><li>A</li><li>B</li></ul>')
+  })
+
+  it('returns an empty string for an empty message', () => {
+    expect(formatValidationErrorHtml('')).toBe('')
+  })
+})

--- a/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.ts
+++ b/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.ts
@@ -1,0 +1,28 @@
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+/**
+ * Builds the HTML body for an element validation error. `message` is the
+ * server-combined violation text, one violation per line. A single violation
+ * renders as a plain line; multiple render as an unordered list. The result is
+ * passed through SanitizeHtml (DOMPurify), which keeps ul/li.
+ */
+export const formatValidationErrorHtml = (message: string): string => {
+  const items = message
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  if (items.length <= 1) {
+    return items[0] ?? ''
+  }
+
+  return `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>`
+}

--- a/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.ts
+++ b/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.ts
@@ -32,5 +32,7 @@ export const formatValidationErrorHtml = (message: string): string => {
     return items[0] ?? ''
   }
 
-  return `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>`
+  const listItems = items.map((item) => `<li>${item}</li>`).join('')
+
+  return `<ul>${listItems}</ul>`
 }

--- a/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.ts
+++ b/assets/js/src/core/modules/app/error-handler/utils/format-validation-error.ts
@@ -8,17 +8,25 @@
  *  @license    Pimcore Open Core License (POCL)
  */
 
+import { escape } from 'lodash'
+
 /**
  * Builds the HTML body for an element validation error. `message` is the
  * server-combined violation text, one violation per line. A single violation
- * renders as a plain line; multiple render as an unordered list. The result is
- * passed through SanitizeHtml (DOMPurify), which keeps ul/li.
+ * renders as a plain line; multiple render as an unordered list.
+ *
+ * Each violation is HTML-escaped before interpolation, so the message text is
+ * always displayed literally: the ul/li wrapper is the only markup, and
+ * SanitizeHtml (DOMPurify) keeps it. Without escaping, HTML-like text in a
+ * message would be rendered as markup (DOMPurify's default allowlist keeps
+ * headings, links, images, list items, …) rather than shown to the user.
  */
 export const formatValidationErrorHtml = (message: string): string => {
   const items = message
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
+    .map((line) => escape(line))
 
   if (items.length <= 1) {
     return items[0] ?? ''


### PR DESCRIPTION
### What

Render element-validation errors as a bulleted list of the server-provided violation messages, instead of one `error.`-prefixed line.

### Why

When saving an element fails validation, the backend (`studio-backend-bundle`) returns HTTP 422 with `errorKey = error_element_validation_failed` and `message` holding the human-readable, server-combined violation text (one violation per line).

`ApiErrorViewUI` treats `errorContent.errorKey` as an i18n key and renders `t(`error.${errorKey}`)`. Because the value is free text (not a translation key), i18next returns the raw string with a literal `error.` prefix, collapsed onto a single line. Users see e.g.:

> error.The button text must not be empty. Link 1: A text must be provided.

This affects **every** element whose validator fails, not just custom classes.

### Fix

Detect the `ELEMENT_VALIDATION_FAILED` case and render the message directly through the existing `SanitizeHtml` (DOMPurify keeps `ul`/`li`), bypassing `t()`: a single violation renders as a plain line, multiple as an unordered list. A small unit-tested helper (`formatValidationErrorHtml`) does the split/format.

- `api-error-view-ui.tsx` — add the `ELEMENT_VALIDATION_FAILED` branch (falls through to the existing behavior for every other error).
- `utils/format-validation-error.ts` (+ `.test.ts`) — new helper, POCL header included.

No change to any other error path.

### Testing

- `npx jest format-validation-error` — single line, multi-line → `<ul>`, blank-line/whitespace trimming, empty input → `''`.
- Manual: save an object with ≥2 failing mandatory/regex validators → the modal shows a clean bulleted list, no `error.` prefix; a single violation shows as one line.
- Content is rendered via the existing `SanitizeHtml`/DOMPurify, so only `ul`/`li` and inline text survive (no new XSS surface).
