### PR TITLE
[Relation] Fix "Invalid column configuration" (422) when relation field has no visibleFields

### DIFF
--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/many-to-many-object-relation/hooks/use-grid-options.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/many-to-many-object-relation/hooks/use-grid-options.tsx
@@ -28,6 +28,9 @@ type IGetDefaultVisibleFieldDefinitionsReturn = Array<{
   key: string
   title: string
   fieldtype: string
+  type: string
+  group: string[]
+  config: object
 }>
 
 export interface UseGridOptionsReturn {
@@ -43,17 +46,26 @@ export const useGridOptions = (): UseGridOptionsReturn => {
     {
       key: 'id',
       title: 'id',
-      fieldtype: 'input'
+      fieldtype: 'input',
+      type: 'system.id',
+      group: ['system'],
+      config: {}
     },
     {
       key: 'fullpath',
       title: t('relations.reference'),
-      fieldtype: 'input'
+      fieldtype: 'input',
+      type: 'system.string',
+      group: ['system'],
+      config: {}
     },
     {
       key: 'classname',
       title: t('relations.class'),
-      fieldtype: 'input'
+      fieldtype: 'input',
+      type: 'system.string',
+      group: ['system'],
+      config: {}
     }
   ])
 

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/many-to-many-object-relation/hooks/use-grid-options.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/many-to-many-object-relation/hooks/use-grid-options.tsx
@@ -30,7 +30,7 @@ type IGetDefaultVisibleFieldDefinitionsReturn = Array<{
   fieldtype: string
   type: string
   group: string[]
-  config: object
+  config: string[]
 }>
 
 export interface UseGridOptionsReturn {
@@ -49,7 +49,7 @@ export const useGridOptions = (): UseGridOptionsReturn => {
       fieldtype: 'input',
       type: 'system.id',
       group: ['system'],
-      config: {}
+      config: []
     },
     {
       key: 'fullpath',
@@ -57,7 +57,7 @@ export const useGridOptions = (): UseGridOptionsReturn => {
       fieldtype: 'input',
       type: 'system.string',
       group: ['system'],
-      config: {}
+      config: []
     },
     {
       key: 'classname',
@@ -65,7 +65,7 @@ export const useGridOptions = (): UseGridOptionsReturn => {
       fieldtype: 'input',
       type: 'system.string',
       group: ['system'],
-      config: {}
+      config: []
     }
   ])
 


### PR DESCRIPTION
Relation preview grids with no configured "Visible Fields" fall back to default columns (id / fullpath / classname). These defaults only carried a key/title, so the POST to /data-objects/grid/{classId} sent columns without a type or config and the backend rejected the whole request with 422 "Invalid column configuration".

Make getDefaultVisibleFieldDefinitions() emit valid columns:
- id -> type: system.id,     group: [system], config: {}
- fullpath -> type: system.string, group: [system], config: {}
- classname -> type: system.string, group: [system], config: {}

The group: [system] also lets getDefaultSystemColumnSize() apply the correct default widths. This covers manyToManyObjectRelation, AdvancedManyToManyObjectRelation and ReverseObjectRelation, which all render through the shared ManyToManyObjectRelation component and this single hook.