### PR TITLE
[Studio UI] Fix 404 on inline-edit object-relation grid in folder listings

### DIFF
--- a/assets/js/src/core/modules/data-object/listing/decorator/class-definition-selection/context-layer/provider/class-definition-selection-provider.tsx
+++ b/assets/js/src/core/modules/data-object/listing/decorator/class-definition-selection/context-layer/provider/class-definition-selection-provider.tsx
@@ -32,21 +32,22 @@ export interface ClassDefinitionSelectionProviderProps {
 }
 
 export const ClassDefinitionSelectionProvider = ({ children, config }: ClassDefinitionSelectionProviderProps): React.JSX.Element => {
-  const { data } = useClassDefinitions()
+  const { scopedData, data } = useClassDefinitions()
+  const availableSource = scopedData ?? data
   const [selectedClassDefinition, setSelectedClassDefinition] = useState<ClassDefinitionSelectionData['selectedClassDefinition']>(undefined)
 
   const availableClassDefinitions = useMemo(() => {
     if (config.classRestriction !== undefined) {
       const restrictedClasses: string[] = config.classRestriction.map((classDefinition) => classDefinition.classes)
-      return data?.items.filter((classDefinition) => restrictedClasses.includes(classDefinition.name)) ?? []
+      return availableSource?.items.filter((classDefinition) => restrictedClasses.includes(classDefinition.name)) ?? []
     }
 
-    if (data !== undefined) {
-      return data.items
+    if (availableSource !== undefined) {
+      return availableSource.items
     }
 
     return []
-  }, [data])
+  }, [availableSource])
 
   let computedSelectedClassDefinition = selectedClassDefinition
 
@@ -58,5 +59,5 @@ export const ClassDefinitionSelectionProvider = ({ children, config }: ClassDefi
     <ClassDefinitionSelectionContext.Provider value={ { config, availableClassDefinitions, selectedClassDefinition: computedSelectedClassDefinition, setSelectedClassDefinition } }>
       {children}
     </ClassDefinitionSelectionContext.Provider>
-  ), [config, availableClassDefinitions, selectedClassDefinition, data])
+  ), [config, availableClassDefinitions, selectedClassDefinition, availableSource])
 }

--- a/assets/js/src/core/modules/data-object/utils/provider/class-defintions/class-definitions-provider.tsx
+++ b/assets/js/src/core/modules/data-object/utils/provider/class-defintions/class-definitions-provider.tsx
@@ -20,7 +20,9 @@ import { Content } from '@Pimcore/components/content/content'
 import { isAllowed } from '@Pimcore/modules/auth/permission-helper'
 import { UserPermission } from '@Pimcore/modules/auth/enums/user-permission'
 
-export type ClassDefinitionsData = TypedUseQueryHookResult<ClassDefinitionCollectionApiResponse, ClassDefinitionCollectionApiArg, BaseQuery>
+export type ClassDefinitionsData = TypedUseQueryHookResult<ClassDefinitionCollectionApiResponse, ClassDefinitionCollectionApiArg, BaseQuery> & {
+  scopedData?: ClassDefinitionCollectionApiResponse
+}
 
 export type ClassDefinitionsContextProps = ClassDefinitionsData | undefined
 
@@ -68,7 +70,7 @@ export const ClassDefinitionsProvider = ({ children, elementId, showLoadingIndic
     trackError(new ApiError(queryResultReturn.error))
   }
 
-  const transformedQueryResult = { ...queryResultReturn }
+  const transformedQueryResult: ClassDefinitionsData = { ...queryResultReturn }
 
   // If user doesn't have objects permission, provide empty data
   if (!hasObjectsPermission) {
@@ -83,8 +85,11 @@ export const ClassDefinitionsProvider = ({ children, elementId, showLoadingIndic
     transformedQueryResult.isFetching = queryResultReturn.isFetching || folderQueryState.isLoading
   }
 
+  // When bound to a folder, expose the folder-scoped subset separately in `scopedData`
+  // instead of overwriting `data`. `data` must stay the full catalog so that identity
+  // lookups (e.g. resolving a relation's allowed class by name) work in listing contexts.
   if (elementId !== undefined && folderQueryState.data !== undefined && queryResultReturn.data !== undefined) {
-    transformedQueryResult.data = {
+    transformedQueryResult.scopedData = {
       ...queryResultReturn.data,
       items: folderQueryState.data.items.map((folderItem) => {
         const classDefinition = queryResultReturn.data?.items.find((item) => item.id === folderItem.id)


### PR DESCRIPTION
## What

Inline-editing a **many-to-many object relation** column in a data-object listing fired a request to `POST /pimcore-studio/api/data-objects/grid/` (empty `classId`) that **404'd**. As a result the related objects — including their **localized values** — never loaded in the inline editor.

## Root cause

`ClassDefinitionsProvider` **overwrote `data`** with the folder-scoped subset whenever it was bound to an `elementId` (i.e. a folder listing). The identity getters `getByName` / `getById` read that same `data`, so inside a folder listing they searched only the folder's classes. A relation's `allowedClasses` can point to any class — one not present in the folder resolves to `undefined` → `?? ''` → URL `data-objects/grid/` → 404.

This is why the bug was **inline-edit-specific**: in the normal object editor the relation component renders under the `default-page` provider (no `elementId`), where `data` is the full catalog and `getByName` worked.

Pre-existing design flaw (folder-scoping of `data` landed in #1367, Apr 2025), surfaced by the newer inline-edit-of-relations-in-listing path.

## Fix

- Keep `data` as the **full class catalog** — never overwrite it.
- Expose the folder-scoped subset in a new dedicated field **`scopedData`** (populated only when an `elementId` is set).
- `getByName` / `getById` now resolve **any** class regardless of folder context → no more empty `classId`.
- Only `ClassDefinitionSelectionProvider` (the folder class-picker dropdown) reads `scopedData`, falling back to `data` when there is no folder scope (`scopedData ?? data`) — preserving its existing folder-scoped behavior.

## Scope / risk

Two files, minimal surface. The only consumer of the folder-scoped subset is the class-selection dropdown, which is explicitly repointed to `scopedData`; every other consumer already goes through the identity getters and benefits from the full catalog. `tsc` and `eslint` pass.

Fixes pimcore/service-operations#966
Fixes pimcore/service-operations#999

🤖 Generated with [Claude Code](https://claude.com/claude-code)