### PR TITLE
Studio Frontend Build: scope push trigger to version branches (fix cancelled (push) checks)

### DIFF
--- a/.github/workflows/studio-frontend-build.yaml
+++ b/.github/workflows/studio-frontend-build.yaml
@@ -1,7 +1,14 @@
 name: "Studio Frontend Build"
 
 on:
+  # Push builds run only on version branches (which have no PR). Feature/PR
+  # branches are covered by the pull_request trigger below — this avoids a
+  # push run and a pull_request run landing in the same concurrency group and
+  # cancelling each other (which surfaced as confusing cancelled "(push)" checks).
   push:
+    branches:
+      - "[0-9]+.x"
+      - "[0-9]+.[0-9]+"
     paths:
       - "assets/**"
   pull_request:


### PR DESCRIPTION
## Problem
Studio Frontend Build triggers on both `push` and `pull_request`. On a PR branch, both events fire and resolve to the **same** concurrency group (`studio-frontend-build-<branch>`), so `cancel-in-progress` cancels one — showing up as cancelled `(push)` checks and a red "Some checks were not successful" on the PR, even though the `pull_request` run passed. Confusing for everyone opening PRs.

## Fix
Scope the `push` trigger to **version branches** (which have no PR and still need build+commit). Feature/PR branches are covered by `pull_request`. Result: each branch triggers exactly **one** run — visible, green, no self-cancellation, and no non-fast-forward race.

No behavior loss: a feature branch just builds via its PR instead of via a redundant push run.

Part of the studio frontend CI standardization (pimcore/product-management#1302).