### PR TITLE
[Bug] Class editor: allowed-classes select shows duplicate options and drops classes (folder nodes leak into options)

### DIFF
--- a/assets/js/src/core/modules/field-definitions/dynamic-types/hooks/use-class-definition-options.spec.ts
+++ b/assets/js/src/core/modules/field-definitions/dynamic-types/hooks/use-class-definition-options.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+import { renderHook } from '@testing-library/react'
+import { useClassDefinitionGetTreeQuery, type ClassDefinitionTreeNodeItem, type ClassDefinitionTreeNodeFolder } from '@sdk/api/class-definition'
+import { useClassDefinitionOptions } from './use-class-definition-options'
+
+jest.mock('@sdk/api/class-definition', () => ({
+  useClassDefinitionGetTreeQuery: jest.fn()
+}))
+
+const mockedUseClassDefinitionGetTreeQuery = useClassDefinitionGetTreeQuery as jest.Mock
+
+const createItem = (name: string): ClassDefinitionTreeNodeItem => ({
+  id: name.toLowerCase(),
+  name,
+  title: name,
+  icon: { type: 'name', value: 'data-object' },
+  group: null,
+  enableGridLocking: false,
+  hasBrickField: false
+})
+
+const createFolder = (name: string, children: ClassDefinitionTreeNodeItem[]): ClassDefinitionTreeNodeFolder => ({
+  id: `folder_${name}`,
+  name,
+  title: name,
+  icon: { type: 'name', value: 'folder' },
+  group: null,
+  children
+})
+
+const mockTreeData = (items: Array<ClassDefinitionTreeNodeItem | ClassDefinitionTreeNodeFolder> | undefined): void => {
+  mockedUseClassDefinitionGetTreeQuery.mockReturnValue({
+    data: items === undefined ? undefined : { items, totalItems: items.length },
+    refetch: jest.fn(),
+    isFetching: false
+  })
+}
+
+describe('useClassDefinitionOptions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('excludes folder nodes so that group names never appear as class options', () => {
+    // Groups derived from class name prefixes create folder nodes named after
+    // existing classes (e.g. folder "Material" containing the class "Material").
+    mockTreeData([
+      createFolder('Material', [createItem('Material'), createItem('MaterialGroup')]),
+      createFolder('Product', [createItem('Product'), createItem('ProductForm')]),
+      createItem('Series')
+    ])
+
+    const { result } = renderHook(() => useClassDefinitionOptions())
+    const values = result.current.options.map((option) => option.value)
+
+    expect(values).toEqual(['Material', 'MaterialGroup', 'Product', 'ProductForm', 'Series'])
+  })
+
+  it('does not produce duplicate option values when a folder shares its name with a class', () => {
+    mockTreeData([
+      createFolder('Material', [createItem('Material'), createItem('MaterialGroup')])
+    ])
+
+    const { result } = renderHook(() => useClassDefinitionOptions())
+    const values = result.current.options.map((option) => option.value)
+
+    expect(values).toHaveLength(new Set(values).size)
+    expect(values.filter((value) => value === 'Material')).toHaveLength(1)
+  })
+
+  it('prepends the special folder option when includeFolder is true', () => {
+    mockTreeData([createItem('Series')])
+
+    const { result } = renderHook(() => useClassDefinitionOptions(true))
+
+    expect(result.current.options).toEqual([
+      { label: 'folder', value: 'folder' },
+      { label: 'Series', value: 'Series' }
+    ])
+  })
+
+  it('returns an empty option list while the tree is not loaded yet', () => {
+    mockTreeData(undefined)
+
+    const { result } = renderHook(() => useClassDefinitionOptions())
+
+    expect(result.current.options).toEqual([])
+  })
+})

--- a/assets/js/src/core/modules/field-definitions/dynamic-types/hooks/use-class-definition-options.ts
+++ b/assets/js/src/core/modules/field-definitions/dynamic-types/hooks/use-class-definition-options.ts
@@ -10,7 +10,7 @@
 
 import { useMemo } from 'react'
 import { useClassDefinitionGetTreeQuery, type ClassDefinitionTreeNodeItem, type ClassDefinitionTreeNodeFolder } from '@sdk/api/class-definition'
-import { flatMap, isArray, isEmpty, isUndefined } from 'lodash'
+import { flatMap, isArray, isUndefined } from 'lodash'
 
 export interface SelectOption {
   label: string
@@ -25,19 +25,20 @@ export interface UseClassDefinitionOptionsReturn {
 
 type TreeNode = ClassDefinitionTreeNodeItem | ClassDefinitionTreeNodeFolder
 
-const hasChildren = (node: TreeNode): node is ClassDefinitionTreeNodeFolder => {
-  return 'children' in node && isArray(node.children) && !isEmpty(node.children)
+const isFolderNode = (node: TreeNode): node is ClassDefinitionTreeNodeFolder => {
+  return 'children' in node && isArray(node.children)
 }
 
 const flattenTreeNodes = (nodes: TreeNode[]): SelectOption[] => {
   return flatMap(nodes, (node) => {
-    const currentNode: SelectOption = { label: node.name, value: node.name }
-
-    if (hasChildren(node)) {
-      return [currentNode, ...flattenTreeNodes(node.children)]
+    // Folder nodes are grouping containers, not selectable class definitions.
+    // Including them would produce options that duplicate class names (a group
+    // is often named after an existing class) or reference non-existent classes.
+    if (isFolderNode(node)) {
+      return flattenTreeNodes(node.children)
     }
 
-    return [currentNode]
+    return [{ label: node.name, value: node.name }]
   })
 }
 


### PR DESCRIPTION
## Changes in this pull request

Resolves pimcore/platform-version#239

`useClassDefinitionOptions` builds the options for the **allowed classes** select shown in the class editor settings of all relation field types (`manyToOneRelation`, `manyToManyRelation`, `manyToManyObjectRelation`, both `advanced*` variants and `reverseObjectRelation`). It fetches the class definition tree with `withGroup: true` and flattens it — but `flattenTreeNodes()` emitted the **folder (group) nodes themselves as selectable options** in addition to their children.

Since `ClassDefinitionTreeService` (studio-backend-bundle) derives group names from class name prefixes for classes without an explicit group, a folder is frequently named exactly like a real class. Example: classes `Material` and `MaterialGroup` are grouped into a folder named `Material`, so the options contain `Material` twice (folder + class) plus phantom entries for groups that are not classes at all (`Royalty`, …).

### Observed behaviour

* The allowed-classes dropdown shows **duplicate entries** (e.g. `Material` twice, `Product` twice).
* The duplicate option values / React keys break rendering of the virtualized dropdown list, so **some perfectly valid classes (e.g. `Series`) no longer show up** and cannot be selected.
* Folder/group names can be picked and saved as an "allowed class" even though no such class exists.

### Reproduction

1. Create classes `Material`, `MaterialGroup` and `Series` (no explicit group set).
2. Add a `manyToOneRelation` field to any class and open its settings in the class editor.
3. Open the *Allowed classes* select: `Material` appears twice, `Series` is missing.

### Fix

Skip folder nodes in `flattenTreeNodes()` and only recurse into their children — folders are grouping containers, not selectable class definitions. This mirrors what the neighbouring `useClassRelationFieldsOptions` hook already does. The special `folder` option added via the `includeFolder` parameter is unaffected.

Added a Jest spec covering: folder nodes excluded, no duplicate values when a folder shares its name with a class, `includeFolder` behaviour, and the not-yet-loaded state.

## Additional info

The root cause has two halves: the prefix-based auto-grouping in `ClassDefinitionTreeService::extractGroupNameFromClassName()` (studio-backend-bundle) is what makes folder names collide with class names in the first place. This PR fixes the consumer side, which resolves the user-facing bug for all relation field types; rethinking the prefix grouping itself is left out of scope.

Reproduced on v2026.1.6 and the bug is still present on `2026.x`/v2026.2.1.
