### PR TITLE
[Symfony 8] Replace deprecated #[TaggedIterator] with #[AutowireIterator]

### DIFF
--- a/.github/workflows/symfony8-compat.yaml
+++ b/.github/workflows/symfony8-compat.yaml
@@ -1,0 +1,10 @@
+name: "Symfony 8 compatibility"
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+jobs:
+  symfony8-compat:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\StudioUiBundle\Branding\BrandingProviderInterface;
 use Pimcore\Bundle\StudioUiBundle\Service\StaticResourcesResolverInterface;
 use Pimcore\Controller\FrontendController;
 use Pimcore\Tool;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -32,7 +32,7 @@ final class DefaultController extends FrontendController
         private StaticResourcesResolverInterface $staticResourcesResolver,
         private UrlServiceInterface $mercureUrlService,
         private BrandingProviderInterface $brandingProvider,
-        #[TaggedIterator('pimcore_studio_ui.app_config_provider')]
+        #[AutowireIterator('pimcore_studio_ui.app_config_provider')]
         private iterable $appConfigProviders,
     ) {
 


### PR DESCRIPTION
## What

Replaces the deprecated `#[TaggedIterator]` attribute with `#[AutowireIterator]` — **1 usage(s)
across 1 file(s)** — and subscribes this repo to the new central Symfony 8 compatibility check.

- `src/Controller/DefaultController.php` — 1 usage(s)

Each file gets exactly two kinds of edit: the import line and the attribute name. **Arguments are
byte-identical**, and no class, file or service name is touched.

## Why

`Symfony\Component\DependencyInjection\Attribute\TaggedIterator` is deprecated since Symfony 7.1 and
**removed in Symfony 8.0** (`UPGRADE-8.0.md`, DependencyInjection).

The swap is a **pure rename**: `TaggedIterator` extends `AutowireIterator`, the constructors are
identical (`$tag, $indexAttribute, $defaultIndexMethod, $defaultPriorityMethod, $exclude, $excludeSelf`),
and `TaggedIterator::__construct()` does nothing but emit `trigger_deprecation()` and forward to its
parent. Behaviour on Symfony 7.4 is unchanged; the only runtime difference is one deprecation less.

## Staying compatible

Adds `.github/workflows/symfony8-compat.yaml`, a thin caller for the new central check
`pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main`
(pimcore/workflows-collection-public#154, merged). Two rules are active today — the `#[TaggedIterator]`
attribute and its import — each as its own named check, annotating the offending line if it ever comes
back. The rule set grows centrally with every further Symfony 8 fix sweep, so no repo has to maintain its
own copy.

## Verification

- `#[TaggedIterator(` → **0**; `#[AutowireIterator(` → **1** (equal to the pre-change count)
- `use …\Attribute\TaggedIterator;` → **0**
- `php -l` clean on every changed file; the diff touches only the files listed above plus the new workflow
- remaining `TaggedIterator` matches in the repo are **class names / `#[AutoconfigureTag]` references** and
  were deliberately left untouched

## Context

Step 1 of the Symfony 7.4 → 8 migration, from the readiness analysis of all 37 platform SBOM repos
(`pimcore/platform-version`, `migration-analysis/SUMMARY.md`). Chosen first because it is the safest
mechanical change in the set. 40 usages across 9 repos are being fixed in one PR per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
