### PR TITLE
[Symfony 8] Extend the DependencyInjection Extension base class

### DIFF
--- a/src/DependencyInjection/PimcoreStudioUiExtension.php
+++ b/src/DependencyInjection/PimcoreStudioUiExtension.php
@@ -18,9 +18,9 @@ use Exception;
 use Pimcore\Bundle\StudioUiBundle\Security\Csp\ContentSecurityPolicyHandlerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.


### PR DESCRIPTION
## What

Switches the bundle extension from the deprecated
`Symfony\Component\HttpKernel\DependencyInjection\Extension` to
`Symfony\Component\DependencyInjection\Extension\Extension`.

**One line changes** — the import. `class … extends Extension` is untouched, because the new parent has
the same short name.


## Why it is a no-op at runtime

The deprecated class is deprecated in Symfony **8.1**, and the replacement **already exists in 7.4 as its
own parent**:

```php
// vendor/symfony/http-kernel/DependencyInjection/Extension.php:23
abstract class Extension extends BaseExtension     // BaseExtension = the DependencyInjection one
```

So this removes a deprecated intermediate from the hierarchy. `instanceof` results are unchanged, no
method resolution changes, and the class stays a valid bundle extension on 7.4 today.

No public API is involved: bundle DI extensions are internal plumbing that integrators do not extend, and
the platform has no aliases, FQCN uses or `instanceof` coupling on this base class.

## Verification

The central check gained an `httpkernel-extension-import` rule
(pimcore/workflows-collection-public#157, merged **before** this PR on purpose), so
**`api-scan (httpkernel-extension-import)` on this PR is the test** — it was failing on this branch's base
and must be green here.

Locally: all central rules extracted from the merged workflow are clean after the edit, `php -l` passes,
the import block is still `ordered_imports`-sorted (the new namespace sorts earlier, so the line moves),
and the diff is exactly one file with one insertion and one deletion.

## Context

Sweep 4 of the Symfony 7.4 → 8 migration, chosen from a review of what remains doable **without any BC
break** (`pimcore/platform-version`, runbook `EXEC-EXTENSION.md`). 19 repos, one line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
