### PR TITLE
[Element Selector] Support searchPath scoping for image field types

### DIFF
--- a/assets/js/src/core/modules/asset/element-selector/asset-selector-listing.tsx
+++ b/assets/js/src/core/modules/asset/element-selector/asset-selector-listing.tsx
@@ -9,6 +9,7 @@
  */
 
 import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useDataQueryHelper } from '../listing/data-layer/use-data-query-helper'
 import { ListingContainer, defaultProps as listingDefaultProps } from '@Pimcore/modules/element/listing/abstract/listing-container'
 import { compose } from '@Pimcore/utils/compose'
@@ -27,6 +28,8 @@ import { TypeFilterDecorator, type TypeFilterDecoratorConfig } from '@Pimcore/mo
 import { StaticColumnConfigurationDecorator } from '@Pimcore/modules/search/modal/tabs/asset/listing/decorator/static-column-configuration/static-column-configuration-decorator'
 import { useAssetGetSearchQuery } from '@Pimcore/modules/search/search-api-slice.gen'
 import { elementTypes } from '@Pimcore/types/enums/element/element-type'
+import { type FilterValues } from '@Pimcore/components/filters'
+import { type FieldFilter } from '@Pimcore/modules/element/listing/decorators/general-filters/context-layer/provider/field-filters/field-filters-provider'
 
 const defaultProps = {
   ...listingDefaultProps,
@@ -38,8 +41,29 @@ const defaultProps = {
 
 export const AssetSelectorListing = (): React.JSX.Element => {
   const { config } = useElementSelectorHelper()
+  const { t } = useTranslation()
 
   const allowedTypes: string[] = config.config?.assets?.allowedTypes ?? []
+  const searchPath = config.config?.assets?.searchPath ?? ''
+
+  // Seed the applied filters with a fullpath filter when a search path is configured
+  // on the field. It is a soft default: the filter is visible in the sidebar and can
+  // be modified or cleared by the user.
+  const initialFilters = useMemo((): FilterValues | undefined => {
+    if (searchPath === '') {
+      return undefined
+    }
+
+    const searchPathFilter: FieldFilter = {
+      key: 'fullpath',
+      type: 'system.string',
+      filterValue: searchPath,
+      locale: null,
+      meta: { translationKey: t('fullpath') }
+    }
+
+    return { fieldFilters: [searchPathFilter] }
+  }, [searchPath, t])
 
   /* eslint-disable @typescript-eslint/consistent-type-assertions */
   const listingProps = useMemo(() => compose<AbstractDecoratorProps>(
@@ -47,7 +71,7 @@ export const AssetSelectorListing = (): React.JSX.Element => {
     StaticColumnConfigurationDecorator,
     [RowSelectionDecorator, { rowSelectionMode: config?.selectionType } as IRowSelectionDecoratorConfig],
     TagFilterDecorator,
-    [GeneralFiltersDecorator, { handleSearchTermInSidebar: false } as GeneralFiltersDecoratorConfig],
+    [GeneralFiltersDecorator, { handleSearchTermInSidebar: false, initialFilters } as GeneralFiltersDecoratorConfig],
     SortingDecorator,
     [GlobalRowSelectionDecorator, { rowSelectionMode: config?.selectionType, elementType: 'asset' } as IGlobalRowSelectionConfig],
     [
@@ -57,7 +81,7 @@ export const AssetSelectorListing = (): React.JSX.Element => {
         elementType: elementTypes.asset
       } as TypeFilterDecoratorConfig
     ]
-  )(defaultProps), [config])
+  )(defaultProps), [config, initialFilters])
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
 
   return useMemo(() => (

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/hotspot-image/footer.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/hotspot-image/footer.tsx
@@ -37,6 +37,7 @@ interface HotspotImageFooterProps {
   replaceImage: (newImage: ImageValue) => void
   onSearch?: () => void
   onUpload?: () => void
+  searchPath?: string
 }
 
 export const HotspotImageFooter = (props: HotspotImageFooterProps): React.JSX.Element => {
@@ -82,7 +83,8 @@ export const HotspotImageFooter = (props: HotspotImageFooterProps): React.JSX.El
         },
         config: {
           assets: {
-            allowedTypes: ['image']
+            allowedTypes: ['image'],
+            searchPath: props.searchPath
           }
         },
         onFinish: (event) => {

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/hotspot-image/hotspot-image.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/hotspot-image/hotspot-image.tsx
@@ -65,6 +65,7 @@ export interface HotspotImageProps {
   ratioX?: number
   ratioY?: number
   uploadPath?: string
+  searchPath?: string
 }
 
 export const HotspotImage = (props: HotspotImageProps): React.JSX.Element => {
@@ -115,7 +116,8 @@ export const HotspotImage = (props: HotspotImageProps): React.JSX.Element => {
     },
     config: {
       assets: {
-        allowedTypes: ['image']
+        allowedTypes: ['image'],
+        searchPath: props.searchPath
       }
     },
     onFinish: (event) => {
@@ -222,6 +224,7 @@ export const HotspotImage = (props: HotspotImageProps): React.JSX.Element => {
           onSearch={ openElementSelector }
           onUpload={ handleUpload }
           replaceImage={ replaceImage }
+          searchPath={ props.searchPath }
           setCropModalOpen={ handleOpenCropModal }
           setMarkerModalOpen={ handleOpenHotspotMarkersModal }
           setValue={ handleChange }

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/components/image-preview/image-preview.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/components/image-preview/image-preview.tsx
@@ -49,9 +49,10 @@ interface ImageGalleryImagePreviewProps {
   ratioY?: number
   predefinedDataTemplates?: DataTemplates | string | null
   uploadPath?: string
+  searchPath?: string
 }
 
-export const ImageGalleryImagePreview = ({ item, index, value, setInternalValue, setValue, disabled, width, height, ratioX, ratioY, predefinedDataTemplates, uploadPath }: ImageGalleryImagePreviewProps): React.JSX.Element => {
+export const ImageGalleryImagePreview = ({ item, index, value, setInternalValue, setValue, disabled, width, height, ratioX, ratioY, predefinedDataTemplates, uploadPath, searchPath }: ImageGalleryImagePreviewProps): React.JSX.Element => {
   const { t } = useTranslation()
   const token = useTheme()
   const { openAsset } = useAssetHelper()
@@ -90,7 +91,8 @@ export const ImageGalleryImagePreview = ({ item, index, value, setInternalValue,
     },
     config: {
       assets: {
-        allowedTypes: ['image']
+        allowedTypes: ['image'],
+        searchPath
       }
     },
     onFinish: (event) => {
@@ -145,10 +147,7 @@ export const ImageGalleryImagePreview = ({ item, index, value, setInternalValue,
 
   const handleOpenCropModal = (): void => {
     if (!isNil(item.image?.id)) {
-      openCropModal(
-        item.image.id,
-        item.crop
-      )
+      openCropModal(item.image.id, item.crop)
     }
   }
   const handleOpenHotspotMarkersModal = (): void => {

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/components/image-target/image-target.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/components/image-target/image-target.tsx
@@ -30,9 +30,10 @@ interface ImageGalleryImageTargetProps {
   width: string
   height: string
   uploadPath?: string
+  searchPath?: string
 }
 
-export const ImageGalleryImageTarget = ({ index, value, setValue, disabled, width, height, uploadPath }: ImageGalleryImageTargetProps): React.JSX.Element => {
+export const ImageGalleryImageTarget = ({ index, value, setValue, disabled, width, height, uploadPath, searchPath }: ImageGalleryImageTargetProps): React.JSX.Element => {
   const { styles } = useStyles()
   const { t } = useTranslation()
   const { triggerUpload } = useUploadModal({})
@@ -46,7 +47,8 @@ export const ImageGalleryImageTarget = ({ index, value, setValue, disabled, widt
     },
     config: {
       assets: {
-        allowedTypes: ['image']
+        allowedTypes: ['image'],
+        searchPath
       }
     },
     onFinish: (event) => {

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/components/sortable-item/sortable-item.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/components/sortable-item/sortable-item.tsx
@@ -38,9 +38,10 @@ export interface ImageGallerySortableItemProps {
   ratioY?: number
   predefinedDataTemplates?: DataTemplates | string | null
   uploadPath?: string
+  searchPath?: string
 }
 
-export const ImageGallerySortableItem = ({ id, index, item, value, setValue, setInternalValue, disabled, width, height, ratioX, ratioY, predefinedDataTemplates, uploadPath }: ImageGallerySortableItemProps): React.JSX.Element => {
+export const ImageGallerySortableItem = ({ id, index, item, value, setValue, setInternalValue, disabled, width, height, ratioX, ratioY, predefinedDataTemplates, uploadPath, searchPath }: ImageGallerySortableItemProps): React.JSX.Element => {
   const sortable = useSortable({
     id,
     transition: {
@@ -75,6 +76,7 @@ export const ImageGallerySortableItem = ({ id, index, item, value, setValue, set
             predefinedDataTemplates={ predefinedDataTemplates }
             ratioX={ ratioX }
             ratioY={ ratioY }
+            searchPath={ searchPath }
             setInternalValue={ setInternalValue }
             setValue={ setValue }
             uploadPath={ uploadPath }
@@ -87,6 +89,7 @@ export const ImageGallerySortableItem = ({ id, index, item, value, setValue, set
             disabled={ disabled }
             height={ height }
             index={ index }
+            searchPath={ searchPath }
             setValue={ setValue }
             uploadPath={ uploadPath }
             value={ value }

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/image-gallery.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image-gallery/image-gallery.tsx
@@ -39,6 +39,7 @@ export interface ImageGalleryProps {
   ratioY?: number
   predefinedDataTemplates?: DataTemplates | string | null
   uploadPath?: string
+  searchPath?: string
 }
 
 export type ImageGalleryValue = ImageGalleryValueItem[]
@@ -167,6 +168,7 @@ export const ImageGallery = (props: ImageGalleryProps): React.JSX.Element => {
                 predefinedDataTemplates={ props.predefinedDataTemplates }
                 ratioX={ props.ratioX }
                 ratioY={ props.ratioY }
+                searchPath={ props.searchPath }
                 setInternalValue={ setInternalValue }
                 setValue={ handleChange }
                 uploadPath={ props.uploadPath }
@@ -181,6 +183,7 @@ export const ImageGallery = (props: ImageGalleryProps): React.JSX.Element => {
             disabled={ props.disabled }
             height={ height! }
             index={ internalValue.length }
+            searchPath={ props.searchPath }
             setValue={ handleChange }
             uploadPath={ props.uploadPath }
             value={ internalValue }

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image/footer.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image/footer.tsx
@@ -34,6 +34,7 @@ interface ImageFooterProps {
   value?: ImageValue | null
   onSearch?: () => void
   onUpload?: () => void
+  searchPath?: string
 }
 
 export const ImageFooter = (props: ImageFooterProps): React.JSX.Element => {
@@ -67,7 +68,8 @@ export const ImageFooter = (props: ImageFooterProps): React.JSX.Element => {
         },
         config: {
           assets: {
-            allowedTypes: ['image']
+            allowedTypes: ['image'],
+            searchPath: props.searchPath
           }
         },
         onFinish: (event) => {

--- a/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image/image.tsx
+++ b/assets/js/src/core/modules/element/dynamic-types/definitions/objects/data-related/components/image/image.tsx
@@ -43,6 +43,7 @@ export interface ImageProps {
   onChange?: (value: ImageValue | null) => void
   className?: string
   uploadPath?: string
+  searchPath?: string
 }
 
 export const Image = (props: ImageProps): React.JSX.Element => {
@@ -65,7 +66,8 @@ export const Image = (props: ImageProps): React.JSX.Element => {
     },
     config: {
       assets: {
-        allowedTypes: ['image']
+        allowedTypes: ['image'],
+        searchPath: props.searchPath
       }
     },
     onFinish: (event) => {
@@ -115,6 +117,7 @@ export const Image = (props: ImageProps): React.JSX.Element => {
           key="image-footer"
           onSearch={ openElementSelector }
           onUpload={ handleUpload }
+          searchPath={ props.searchPath }
           setValue={ handleChange }
           value={ imageValue }
         />)

--- a/assets/js/src/core/modules/element/element-selector/provider/element-selector/element-selector-provider.tsx
+++ b/assets/js/src/core/modules/element/element-selector/provider/element-selector/element-selector-provider.tsx
@@ -46,6 +46,7 @@ export interface ElementSelectorConfig {
   config?: {
     assets?: {
       allowedTypes?: IRelationAllowedTypesDataComponent['allowedAssetTypes']
+      searchPath?: string
     }
 
     documents?: {
@@ -68,7 +69,8 @@ export const defaultElementSelectorConfig: ElementSelectorConfig = {
   },
   config: {
     assets: {
-      allowedTypes: undefined
+      allowedTypes: undefined,
+      searchPath: undefined
     },
     documents: {
       allowedTypes: undefined

--- a/assets/js/src/core/modules/element/listing/decorators/general-filters/context-layer/with-tag-filter-context.tsx
+++ b/assets/js/src/core/modules/element/listing/decorators/general-filters/context-layer/with-tag-filter-context.tsx
@@ -18,7 +18,10 @@ export const withGeneralFiltersContext = (Component: AbstractDecoratorProps['Con
   const GeneralFiltersContextComponent = (): React.JSX.Element => {
     return (
       <GeneralFiltersConfigProvider config={ config }>
-        <AppliedFiltersProvider descriptors={ elementFilterDefinitions }>
+        <AppliedFiltersProvider
+          descriptors={ elementFilterDefinitions }
+          initialValues={ config?.initialFilters }
+        >
           <Component />
         </AppliedFiltersProvider>
       </GeneralFiltersConfigProvider>

--- a/assets/js/src/core/modules/element/listing/decorators/general-filters/general-filters-decorator.ts
+++ b/assets/js/src/core/modules/element/listing/decorators/general-filters/general-filters-decorator.ts
@@ -8,6 +8,7 @@
  *  @license    Pimcore Open Core License (POCL)
  */
 
+import { type FilterValues } from '@Pimcore/components/filters'
 import { type AbstractDecorator } from '../abstract-decorator'
 import { withGeneralFiltersContext } from './context-layer/with-tag-filter-context'
 import { withGeneralFiltersQueryArg } from './data-layer/with-general-filters-query-arg'
@@ -16,6 +17,7 @@ import { withGeneralFiltersTab } from './view-layer/components/sidebar/hooks/wit
 export interface GeneralFiltersDecoratorConfig {
   handleSearchTermInSidebar: boolean
   showOnlyUnreferencedFilter?: boolean
+  initialFilters?: FilterValues
 }
 
 export const GeneralFiltersDecorator: AbstractDecorator<GeneralFiltersDecoratorConfig> = (props, config) => {

--- a/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/image/field-definition-image-form-fields.tsx
+++ b/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/image/field-definition-image-form-fields.tsx
@@ -48,6 +48,21 @@ export const FieldDefinitionImageFormFields = (props: FieldDefinitionAbstractFor
       )
         }
 
+      {!isCustomLayout && (
+      <Form.Item
+        label={ t('search-path') }
+        name="searchPath"
+        tooltip={ t('search-path-tooltip') }
+      >
+        <ManyToOneRelationPath
+          allowToClearRelation
+          allowedAssetTypes={ ['folder'] }
+          assetsAllowed
+        />
+      </Form.Item>
+      )
+        }
+
     </>
   )
 }

--- a/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/imageAdvanced/field-definition-image-advanced-form-fields.tsx
+++ b/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/imageAdvanced/field-definition-image-advanced-form-fields.tsx
@@ -49,6 +49,18 @@ export const FieldDefinitionImageAdvancedFormFields = (props: FieldDefinitionAbs
           />
         </Form.Item>
 
+        <Form.Item
+          label={ t('search-path') }
+          name="searchPath"
+          tooltip={ t('search-path-tooltip') }
+        >
+          <ManyToOneRelationPath
+            allowToClearRelation
+            allowedAssetTypes={ ['folder'] }
+            assetsAllowed
+          />
+        </Form.Item>
+
         <FieldDefinitionCropPanel />
       </>
       )}

--- a/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/imageGallery/field-definition-image-gallery-form-fields.tsx
+++ b/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/imageGallery/field-definition-image-gallery-form-fields.tsx
@@ -49,6 +49,18 @@ export const FieldDefinitionImageGalleryFormFields = (props: FieldDefinitionAbst
           />
         </Form.Item>
 
+        <Form.Item
+          label={ t('search-path') }
+          name="searchPath"
+          tooltip={ t('search-path-tooltip') }
+        >
+          <ManyToOneRelationPath
+            allowToClearRelation
+            allowedAssetTypes={ ['folder'] }
+            assetsAllowed
+          />
+        </Form.Item>
+
         <FieldDefinitionCropPanel />
       </>
       )

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -1268,6 +1268,8 @@ jobs.data-object-clone-job.title: Cloning data objects
 latitude: Latitude
 longitude: Longitude
 search-address: Search address
+search-path: Search Path
+search-path-tooltip: Default asset folder for the search dialog of this field. It is applied as a pre-filled full path filter, which can be changed or removed in the search dialog.
 search: Search
 geocode.address-not-found: The entered address was not found
 geocode.possible-causes: Possible causes


### PR DESCRIPTION
Adds support for the new "searchPath" class-definition option on the Image, Image Advanced (hotspotimage) and Image Gallery data types (companion to the pimcore/pimcore core change, refs pimcore/pimcore#17157).

When a search path is configured on the field, the asset selector opens with a pre-applied "fullpath" filter seeded from it. The filter is a soft default: it is visible in the selector's Filters sidebar and can be modified or cleared by the user.

- element selector config: new config.assets.searchPath option
- GeneralFiltersDecorator: new initialFilters config, passed as initialValues to the applied-filters store (reset still clears to the unseeded defaults)
- asset selector listing: seeds a fullpath field filter from searchPath
- image / hotspot-image / image-gallery components: thread searchPath from the field definition into every element-selector call site
- class editor: "Search Path" folder picker next to "Upload Path" for all three field definition forms


Claude-Session: https://claude.ai/code/session_01Rf6z83yKPGdQKoVS5B2UeT

## Changes in this pull request
Resolves https://github.com/pimcore/pimcore/issues/17157
Tracking issue: pimcore/platform-version#433

## Additional info
