### PR TITLE
[Class Editor] Add Calculator Data field to the Calculated Value definition

### DIFF
--- a/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/calculatedValue/field-definition-calculated-value-form-fields.tsx
+++ b/assets/js/src/core/modules/field-definitions/dynamic-types/types/data/calculatedValue/field-definition-calculated-value-form-fields.tsx
@@ -9,7 +9,7 @@
  */
 
 import { type FieldDefinitionAbstractFormFieldsProps } from '@Pimcore/modules/field-definitions/dynamic-types/dynamic-type-field-definition-abstract'
-import { Form, Input, InputNumber, Select } from '@sdk/components'
+import { Form, Input, InputNumber, Select, TextArea } from '@sdk/components'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -88,6 +88,14 @@ export const FieldDefinitionCalculatedValueFormFields = (props: FieldDefinitionA
             <Input />
           </Form.Item>
         </Form.Conditional>
+
+        <Form.Item
+          label={ t('calculator-data') }
+          name="calculatorData"
+          tooltip={ t('calculator-data-tooltip') }
+        >
+          <TextArea autoSize />
+        </Form.Item>
       </>
       )}
     </>

--- a/translations/studio.de.yaml
+++ b/translations/studio.de.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp ohne Begrenzer, muss in JS funktionieren (Begrenzer
 test-string: Testzeichenkette
 regex-validation-error-message: Die Zeichenkette entspricht nicht dem erforderlichen Format.
 calculator-class: Berechnungsklasse
+calculator-data: Berechnungsdaten
+calculator-data-tooltip: Optionale Freitext-Daten, die an die Berechnung übergeben werden, z. B. ein einfacher Wert, eine kommagetrennte Liste oder eine JSON-kodierte Struktur.
 calculator-expression: Berechnungsausdruck
 calculator-type: Berechnungstyp
 calculator-type-tooltip: Lesen Sie die offizielle Dokumentation, um mehr über das Definieren von Ausdrücken oder Klassen zu erfahren.

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp without delimiters, has to work in JS (Delimiter: #
 test-string: Test string
 regex-validation-error-message: The string does not match the required format.
 calculator-class: Calculator Class
+calculator-data: Calculator Data
+calculator-data-tooltip: Optional free-form data passed to the calculator, e.g. a plain value, a comma-separated list or a JSON encoded structure.
 calculator-expression: Calculator Expression
 calculator-type: Calculator Type
 calculator-type-tooltip: See the official documentation to learn more about defining expressions or classes.

--- a/translations/studio.es.yaml
+++ b/translations/studio.es.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp sin delimitadores, debe funcionar en JS (Delimitado
 test-string: Cadena de prueba
 regex-validation-error-message: La cadena no coincide con el formato requerido.
 calculator-class: Clase de calculadora
+calculator-data: Datos de calculadora
+calculator-data-tooltip: Datos opcionales de formato libre que se pasan a la calculadora, p. ej. un valor simple, una lista separada por comas o una estructura codificada en JSON.
 calculator-expression: Expresión de calculadora
 calculator-type: Tipo de calculadora
 calculator-type-tooltip: Consulte la documentación oficial para obtener más información sobre cómo definir expresiones o clases.

--- a/translations/studio.fr.yaml
+++ b/translations/studio.fr.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp sans délimiteurs, doit fonctionner en JS (Délimit
 test-string: Chaîne de test
 regex-validation-error-message: La chaîne ne correspond pas au format requis.
 calculator-class: Classe du calculateur
+calculator-data: Données du calculateur
+calculator-data-tooltip: Données libres facultatives transmises au calculateur, p. ex. une valeur simple, une liste séparée par des virgules ou une structure encodée en JSON.
 calculator-expression: Expression du calculateur
 calculator-type: Type de calculateur
 calculator-type-tooltip: Consultez la documentation officielle pour en savoir plus sur la définition des expressions ou des classes.

--- a/translations/studio.it.yaml
+++ b/translations/studio.it.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp senza delimitatori, deve funzionare in JS (Delimita
 test-string: Stringa di test
 regex-validation-error-message: La stringa non corrisponde al formato richiesto.
 calculator-class: Classe calcolatore
+calculator-data: Dati calcolatore
+calculator-data-tooltip: Dati opzionali in formato libero passati al calcolatore, ad es. un valore semplice, un elenco separato da virgole o una struttura codificata in JSON.
 calculator-expression: Espressione calcolatore
 calculator-type: Tipo calcolatore
 calculator-type-tooltip: Consultare la documentazione ufficiale per saperne di più sulla definizione di espressioni o classi.

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp uten skilletegn, må fungere i JS (Skilletegn: #)"
 test-string: Teststreng
 regex-validation-error-message: Strengen samsvarer ikke med det påkrevde formatet.
 calculator-class: Kalkulatorklasse
+calculator-data: Kalkulatordata
+calculator-data-tooltip: Valgfrie fritekstdata som sendes til kalkulatoren, f.eks. en enkel verdi, en kommaseparert liste eller en JSON-kodet struktur.
 calculator-expression: Kalkulatoruttrykk
 calculator-type: Kalkulatortype
 calculator-type-tooltip: Se den offisielle dokumentasjonen for å lære mer om å definere uttrykk eller klasser.

--- a/translations/studio.sv.yaml
+++ b/translations/studio.sv.yaml
@@ -1020,6 +1020,8 @@ regex-flags-tooltip: "RegExp utan avgränsare, måste fungera i JS (Avgränsare:
 test-string: Teststräng
 regex-validation-error-message: Strängen matchar inte det obligatoriska formatet.
 calculator-class: Kalkylatorklass
+calculator-data: Kalkylatordata
+calculator-data-tooltip: Valfria fritextdata som skickas till kalkylatorn, t.ex. ett enkelt värde, en kommaseparerad lista eller en JSON-kodad struktur.
 calculator-expression: Kalkylatoruttryck
 calculator-type: Kalkylatortyp
 calculator-type-tooltip: Se den officiella dokumentationen för att lära dig mer om att definiera uttryck eller klasser.


### PR DESCRIPTION
## Changes in this pull request
Companion to pimcore/pimcore#19138, which adds an optional free-form `calculatorData` string to the `CalculatedValue` field definition that calculator classes and expressions can read via `getCalculatorData()`.

- Adds a **Calculator Data** field to the Calculated Value type's specific settings in the class editor, rendered as an auto-sizing textarea since the value can be a plain value, a comma-separated list or a JSON encoded structure.
- The field is shown for both calculator types (class and expression, since both can access the value) and hidden in custom-layout mode, matching the existing calculator fields.
- Adds the `calculator-data` / `calculator-data-tooltip` translation keys to all seven language files (en, de, es, fr, it, no, sv).

No other wiring is needed: the field-definition form values map generically onto the class definition JSON, so the backend setter introduced in pimcore/pimcore#19138 picks up `calculatorData` on save.

Ref: https://github.com/pimcore/platform-version/issues/429

## Additional info
Verified with ESLint on the changed module, `tsc --noEmit`, and the field-definitions Jest tests — all pass. The compiled frontend build is committed automatically by CI, so only source changes are included.