### PR TITLE
[Studio UI] Apply sentence case to buttons, modals, and toggles acros…

### DIFF
--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -124,7 +124,7 @@ document.tree.context-menu.add-snippet: New Snippet
 document.tree.context-menu.add-email: New Email
 document.tree.context-menu.add-link: New Link
 document.tree.context-menu.add-hardlink: New Hardlink
-document.required-fields.validation-title: Required Fields Missing
+document.required-fields.validation-title: Required fields missing
 document.required-fields.validation-message: The following required fields must be filled before publishing
 document.site.remove-site: Remove site
 document.site.remove-site-confirmation: Are you sure you want to remove this site? This action cannot be undone.
@@ -755,13 +755,13 @@ maximum-items: Maximum Items
 enforce-validation: Enforce Validation
 options-source: Options Source
 options-source-configure: Configure
-options-source-select-options: Select options
+options-source-select-options: Select Options
 options-source-options-provider: Options Provider
 options-provider-class: Options Provider Class or Service Name
 options-provider-data: Options Provider Data
 switch-to-selection-mode: Switch to selection mode
 switch-to-drag-mode: Switch to drag mode
-select-options: Select options
+select-options: Select Options
 value: Value
 display-name: Display Name
 default-values-settings: Default value settings
@@ -1151,8 +1151,8 @@ form.validation.provide-description: Please provide a description
 form.label.new-item: Enter the name of the new item
 thumbnail: Thumbnail
 select-image-preview: Select image preview
-choose-media: Choose Media
-current-player-position: Current Player Position
+choose-media: Choose media
+current-player-position: Current player position
 drag-and-drop-asset: Drag and Drop Asset
 ok: OK
 apply: Apply
@@ -1330,7 +1330,7 @@ tree.actions.clone: Clone
 tree.actions.copy: Copy
 tree.actions.paste: Paste
 tree.actions.delete: Delete
-tree.actions.add-user: Add user
+tree.actions.add-user: Add User
 tree.actions.clone-user: Clone user
 tree.actions.remove-user: Delete user
 tree.actions.folder: Folder
@@ -1340,10 +1340,10 @@ tree.actions.add-tag: New Tag
 tree.actions.delete-tag: Delete
 tree.actions.rename-tag: Rename
 tree.actions.role: Role
-tree.actions.add-role: Add role
+tree.actions.add-role: Add Role
 tree.actions.clone-role: Clone role
 tree.actions.remove-role: Delete role
-tree.actions.remove-folder: Remove folder
+tree.actions.remove-folder: Remove Folder
 tag-configuration.new: New
 tag-configuration.new-tag: New Tag
 tag-configuration.name: Name
@@ -2325,7 +2325,7 @@ test-email.parameters.columns.key: Key
 test-email.parameters.columns.value: Value
 test-email.parameters.add: Add parameter
 test-email.send.error: An error occurred while sending the test email
-test-email.success.modal.title: Sent Test-Email
+test-email.success.modal.title: Sent test email
 test-email.success.modal.text: Your test-email has been sent. Would you like to keep this window open to send the email again?
 test-email.validation.documentPath.required: Please provide a document path
 test-email.validation.documentParameters.required: Please provide at least one parameter

--- a/translations/studio.en.yaml
+++ b/translations/studio.en.yaml
@@ -7,7 +7,7 @@ cache.clear-cache-success: Cache successfully cleared
 cache.clear-full-page-cache-success: Full page cache successfully cleared
 cache.clear-temporary-files-success: Temporary files successfully cleared
 dont-ask-again: "Don't ask again"
-widget.missing-context.title: Missing Context
+widget.missing-context.title: Missing context
 widget.missing-context.description: No related element found
 widget.missing-tab-context.description: This feature is not supported for the related element
 block: Block
@@ -115,7 +115,7 @@ document.hardlink.children-from-source: Use children from source document
 document.paste-as-new-language-variant: Paste as new language variant
 document.paste-as-new-language-variant-recursive: Paste as new language variant (recursive)
 document.paste-language-recursive-updating-references: Paste language (recursive), updating references
-document.select-language-for-new-document: Select language for New Document
+document.select-language-for-new-document: Select language for new document
 document.language-required: Please select a language
 document.paste-inheritance: Paste (inheritance)
 document.tree.copy-paste.replacing-content: Replacing Content
@@ -126,10 +126,10 @@ document.tree.context-menu.add-link: New Link
 document.tree.context-menu.add-hardlink: New Hardlink
 document.required-fields.validation-title: Required Fields Missing
 document.required-fields.validation-message: The following required fields must be filled before publishing
-document.site.remove-site: Remove Site
+document.site.remove-site: Remove site
 document.site.remove-site-confirmation: Are you sure you want to remove this site? This action cannot be undone.
-document.site.use-as-site: Use as Site
-document.site.edit-site: Edit Site
+document.site.use-as-site: Use as site
+document.site.edit-site: Edit site
 document.site.form.main-domain: Main Domain
 document.site.form.additional-domains: Additional Domains
 document.site.form.additional-domains-tooltip: Enter additional domains, one per line. Wildcards are supported (*example.com)
@@ -137,14 +137,14 @@ document.site.form.redirect-to-main-domain: Redirect additional domains to main 
 document.site.form.error-documents: Error Documents
 document.site.form.default-error-document: Default Error Document
 document.site.form.error-document-language: Error Document ({{language}})
-save-and-continue: Save and Continue
-discard-and-continue: Discard and Continue
-discard-changes: Discard Changes
-unsaved-changes.title: Unsaved Changes
+save-and-continue: Save and continue
+discard-and-continue: Discard and continue
+discard-changes: Discard changes
+unsaved-changes.title: Unsaved changes
 unsaved-changes.message: You have unsaved changes. If you continue without saving, these changes will be lost.
 unsaved-changes.close-message: You have unsaved changes. Are you sure you want to close without saving?
 convert-to: Convert to
-convert-document: Convert Document
+convert-document: Convert document
 convert-document-warning: All content will be lost. Are you sure you want to convert this document?
 page: Page
 email: Email
@@ -157,8 +157,8 @@ data-object.select-class-to-display: Select a class to display
 data-object.tree.context-menu.add-object: New Object
 data-object.tree.context-menu.add-variant: New Variant
 data-object.variant-listing.create-data-variant: New Variant
-data-object.create-data-object: Add new Object of type {{className}}
-data-object.create-variant: Add new Variant of type {{className}}
+data-object.create-data-object: Add new object of type {{className}}
+data-object.create-variant: Add new variant of type {{className}}
 data-object.object-editor-tabs.variants: Variants
 object.object-editor-tabs.children-listing: Children Grid
 workflow.label: Workflow
@@ -168,7 +168,7 @@ folder.folder-editor-tabs.preview: Preview
 folder.folder-editor-tabs.view: List
 toolbar.reload.confirmation: Are you sure you want to reload this tab? All unsaved changes will be lost.
 toolbar.reload: Reload
-toolbar.save-and-publish: Save & Publish
+toolbar.save-and-publish: Save & publish
 toolbar.save: Save
 toolbar.save-draft: Save draft
 toolbar.more: More
@@ -182,13 +182,13 @@ language-comparison-view.apply-changes: Apply changes
 language-comparison-view.title: Language comparison
 language-comparison-view.no-localized-fields: This data object has no localized fields.
 language-comparison-view.no-permission: You don't have permission to save this object.
-class-definition.import: Import Class Definition
-class-definition.export: Export Class Definition
+class-definition.import: Import class definition
+class-definition.export: Export class definition
 class-definition.import-file-label: Select JSON file
 class-definition.import-success: Class definition imported successfully
 class-definition.export-success: Class definition exported successfully
 class-definition.custom-layouts.default-layout: Default Layout
-class-definition.create-new: Create New Class Definition
+class-definition.create-new: Create new class definition
 class-definition.class-name: Class name
 class-definition.unique-identifier: Unique identifier
 class-definition.unique-identifier-warning: Be careful with the unique identifier because table names can contain only up to 64 characters.
@@ -206,17 +206,17 @@ class-definition.general-settings.icon: Icon
 class-definition.general-settings.parent-class: Parent Class
 class-definition.general-settings.implements-interfaces: Implements Interfaces
 class-definition.general-settings.listing-parent-class: Listing Parent Class
-class-definition.general-settings.use-traits: Use Traits
-class-definition.general-settings.listing-use-traits: Listing Use Traits
+class-definition.general-settings.use-traits: Use traits
+class-definition.general-settings.listing-use-traits: Listing use traits
 class-definition.general-settings.link-generator-reference: Link Generator Reference
 class-definition.general-settings.preview-generator-reference: Preview Generator Reference
-class-definition.general-settings.allow-inherit: Allow Inheritance
-class-definition.general-settings.allow-variants: Allow Variants
-class-definition.general-settings.show-variants: Show Variants
-class-definition.general-settings.show-app-logger-tab: Show App Logger Tab
-class-definition.general-settings.show-field-lookup: Show Field Lookup
-class-definition.general-settings.enable-grid-locking: Enable Grid Locking
-class-definition.general-settings.encrypt-data: Encrypt Data
+class-definition.general-settings.allow-inherit: Allow inheritance
+class-definition.general-settings.allow-variants: Allow variants
+class-definition.general-settings.show-variants: Show variants
+class-definition.general-settings.show-app-logger-tab: Show app logger tab
+class-definition.general-settings.show-field-lookup: Show field lookup
+class-definition.general-settings.enable-grid-locking: Enable grid locking
+class-definition.general-settings.encrypt-data: Encrypt data
 class-definition.general-settings.enter-name: Please enter a name
 class-definition.property-visibility.title: Property Visibility
 class-definition.property-visibility.id-grid: ID (Grid)
@@ -244,7 +244,7 @@ class-definition.composite-indices.type-localized-query: Localized Query
 class-definition.composite-indices.type-store: Store
 class-definition.composite-indices.type-localized-store: Localized Store
 class-definition.composite-indices.index-label: Index
-field-collection.create-new: Create New Field Collection
+field-collection.create-new: Create new field collection
 field-collection.key: Key
 field-collection.validation.enter-key: Please enter a key
 field-collection.validation.key-format: The key must start with a letter and can contain only letters, numbers, and underscores.
@@ -258,7 +258,7 @@ field-collection.general-settings.implements-interfaces: Implements Interfaces
 field-collection.general-settings.usages.title: Usages
 field-collection.general-settings.usages.class: Class
 field-collection.general-settings.usages.field: Field
-object-brick.create-new: Create New Object Brick
+object-brick.create-new: Create new object brick
 object-brick.key: Key
 object-brick.validation.enter-key: Please enter a key
 object-brick.validation.key-format: The key must start with a letter and can contain only letters, numbers, and underscores.
@@ -273,24 +273,24 @@ object-brick.class-definitions-block.classname: Class
 object-brick.class-definitions-block.select-classname: Select class
 object-brick.class-definitions-block.fieldname: Field
 object-brick.class-definitions-block.select-fieldname: Select field
-select-option.create-new: Create New Select Option
+select-option.create-new: Create new select option
 select-option.id: ID
 select-option.enter-name-new-item: Enter the name of the new item
 select-option.validation.enter-id: Please enter an ID
 select-option.validation.id-format: The name must start with a capital letter, followed by alphanumeric characters
 select-option.general-settings.title: General
 select-option.general-settings.enum-name: Enum Name
-select-option.general-settings.use-traits: Use Traits
+select-option.general-settings.use-traits: Use traits
 select-option.general-settings.implements-interfaces: Implements Interfaces
 select-option.general-settings.group: Group
-select-option.general-settings.admin-only: Admin Only
+select-option.general-settings.admin-only: Admin only
 select-option.entries.title: Options
 select-option.entries.display-name: Display Name
 select-option.entries.value: Value
 select-option.entries.name: Name
 select-option.entries.action: Action
-select-option.entries.move-up: Move Up
-select-option.entries.move-down: Move Down
+select-option.entries.move-up: Move up
+select-option.entries.move-down: Move down
 select-option.general-settings.usages.title: Usages
 select-option.general-settings.usages.class: Class
 select-option.general-settings.usages.field: Field
@@ -356,7 +356,7 @@ grid.configuration.save-template: Save as template
 grid.configuration.save-new-template: Save as new template
 grid.configuration.update-template: Update the template
 grid.configuration.edit-template-details: Edit template details
-grid.configuration.delete-template: Delete Template
+grid.configuration.delete-template: Delete template
 grid.configuration.delete-this-template: Delete this template
 grid.configuration.delete-template-confirmation: Are you sure that you want to delete this template?
 grid.configuration.save-template-configuration: Save configuration as template
@@ -375,7 +375,7 @@ grid.advanced-column.preview: Preview
 grid.advanced-column.no-preview: No preview item available
 grid.advanced-column.no-preview-data: No preview data available
 grid.advanced-column.error-preview-data: Error loading preview
-grid.advanced-column.preview-item: Preview Item
+grid.advanced-column.preview-item: Preview item
 grid.advanced-column.trim: Trim
 grid.advanced-column.find: Find
 grid.advanced-column.replace: Replace
@@ -416,7 +416,7 @@ component.pql.description: Pimcore Query Language (PQL) is a simple yet powerful
 asset.asset-editor-tabs.embedded-metadata.headline: Meta Info
 asset.asset-editor-tabs.embedded-metadata.columns.name: Name
 asset.asset-editor-tabs.embedded-metadata.columns.value: Value
-asset.asset-editor-tabs.preview.open-in-new-window: Open in New Window
+asset.asset-editor-tabs.preview.open-in-new-window: Open in new window
 login-form.remember-me: Remember me
 login-form.forgot-password: Forgot password
 login-form.login: Login
@@ -464,7 +464,7 @@ version.additionalAttributes: Additional Attributes
 version.image: Image
 version.no-versions-to-show: There are no versions to show.
 version.no-preview-available: No preview available for this file.
-version.clear-unpublished: Clear Unpublished
+version.clear-unpublished: Clear unpublished
 version.clear-unpublished-versions: Clear unpublished versions
 version.confirm-clear-unpublished: Are you sure you want to clear all unpublished versions?
 version.preview-notification: Preview details will be displayed once a version is selected.
@@ -569,20 +569,20 @@ data-type.asset: Asset
 data-type.object: Object
 data-type.checkbox: Checkbox
 data-type.select: Select
-open-data-object.button: Open Data Object
-open-data-object-modal.title: Open Data Object
+open-data-object.button: Open data object
+open-data-object-modal.title: Open data object
 open-data-object-modal.label: Please enter the ID or Path of the data object
 open-data-object-modal.required-message: Please enter an ID or Path
 open-data-object-modal.ok-button: OK
 open-data-object-modal.cancel-button: Cancel
-open-asset.button: Open Asset
-open-asset-modal.title: Open Asset
+open-asset.button: Open asset
+open-asset-modal.title: Open asset
 open-asset-modal.label: Please enter the ID or Path of the asset
 open-asset-modal.ok-button: OK
 open-asset-modal.cancel-button: Cancel
 open-asset-modal.required-message: Please enter an ID or Path of the document
-open-document.button: Open Document
-open-document-modal.title: Open Document
+open-document.button: Open document
+open-document-modal.title: Open document
 open-document-modal.label: Please enter the ID or Path of the document
 open-document-modal.ok-button: OK
 open-document-modal.cancel-button: Cancel
@@ -673,10 +673,10 @@ button.apply: Apply
 button.cancel: Cancel
 button.save: Save
 button.confirm: Confirm
-button.save-apply: Save & Apply
-button.add-edit: Add & Edit
+button.save-apply: Save & apply
+button.add-edit: Add & edit
 button.cancel-edits: Cancel edits
-toggle.advanced-mode: Advanced Mode
+toggle.advanced-mode: Advanced mode
 actions.open: Open
 open: Open
 edit: Edit
@@ -755,13 +755,13 @@ maximum-items: Maximum Items
 enforce-validation: Enforce Validation
 options-source: Options Source
 options-source-configure: Configure
-options-source-select-options: Select Options
+options-source-select-options: Select options
 options-source-options-provider: Options Provider
 options-provider-class: Options Provider Class or Service Name
 options-provider-data: Options Provider Data
 switch-to-selection-mode: Switch to selection mode
 switch-to-drag-mode: Switch to drag mode
-select-options: Select Options
+select-options: Select options
 value: Value
 display-name: Display Name
 default-values-settings: Default value settings
@@ -794,10 +794,10 @@ field-definitions.general-settings: General Settings
 field-definitions.base: Base
 field-definitions.configuration-invalid: Configuration contains invalid field definitions.
 field-definitions.saved-successfully: Saved successfully.
-field-definitions.select-item-configuration: Select Item Configuration
+field-definitions.select-item-configuration: Select item configuration
 field-definitions.custom-layout-title: Custom Layout
 field-definitions.custom-layouts: Custom Layouts
-field-definitions.create-new-class-definition: Create New Custom Layout
+field-definitions.create-new-class-definition: Create new custom layout
 field-definitions.select-field-message: Please select a field from the tree to edit its properties.
 field-definitions.loading-general-settings: Loading general settings...
 field-definitions.type-not-supported: Type not supported
@@ -881,7 +881,7 @@ crop-settings: Crop Settings
 ratio-x: Ratio X
 ratio-y: Ratio Y
 predefined-data-templates: Predefined data templates
-upload-path: Upload Path
+upload-path: Upload path
 preview-width: Preview width
 preview-height: Preview height
 url-width: URL width
@@ -1048,10 +1048,10 @@ localized: Localized
 allowed-group-ids: Allowed Group IDs (csv)
 store: Store
 label: Label
-hide-empty-data: Hide Empty Data
+hide-empty-data: Hide empty data
 tab-position: Tab Position
 maximum-tabs: Maximum Tabs
-hide-labels-when-tabs-reached: Hide Locale Labels When Tabs Reached
+hide-labels-when-tabs-reached: Hide locale labels when tabs reached
 data: Data
 domain-label-width: Domain label width
 controller-action: Controller action
@@ -1101,24 +1101,24 @@ jobs.job.download-error: Download failed
 jobs.job.download-not-available: The download is no longer available.
 jobs.job.button-show-errors: Show errors
 jobs.job.error-modal.title: Job Errors
-jobs.job.button-abort: Abort Job
+jobs.job.button-abort: Abort job
 jobs.job.abort-confirm: Do you really want to abort this job?
 jobs.job.step.batch-edit.preparing: Preparing batch edit
 jobs.job.step.batch-edit.applying: Applying batch edit
 jobs.zip-job.title: "ZIP download of {{title}}"
 jobs.csv-job.title: "CSV download of {{title}}"
 jobs.xlsx-job.title: "XLSX download of {{title}}"
-batch-edit.job-title: Batch Edit
+batch-edit.job-title: Batch edit
 jobs.zip-upload-job.title: Upload ZIP
 jobs.zip-upload-job.step1.title: Extracting ZIP
 jobs.zip-upload-job.step2.title: Creating assets
 jobs.download-csv-job.title: CSV export
 jobs.download-xlsx-job.title: XLSX export
 jobs.download-zip-job.title: ZIP download
-batch-edit.modal-title: Batch Edit
+batch-edit.modal-title: Batch edit
 batch-edit.no-content: There are no added columns yet
 batch-edit.modal-footer.apply-changes: Apply changes
-batch-edit.modal-footer.discard-all-changes: Discard All Changes
+batch-edit.modal-footer.discard-all-changes: Discard all changes
 batch-edit.modal-footer.add-a-column: Add a column
 batch-edit.append-mode.replace: Batch replace
 batch-edit.append-mode.add: Batch add
@@ -1150,7 +1150,7 @@ form.validation.provide-name: Please provide a name
 form.validation.provide-description: Please provide a description
 form.label.new-item: Enter the name of the new item
 thumbnail: Thumbnail
-select-image-preview: Select Image Preview
+select-image-preview: Select image preview
 choose-media: Choose Media
 current-player-position: Current Player Position
 drag-and-drop-asset: Drag and Drop Asset
@@ -1229,15 +1229,15 @@ element.delete.batch.dependencies-warning.confirmed_one: 'Please note: This item
 element.delete.batch.dependencies-warning.confirmed_other: 'Please note: These items have dependencies.'
 element.open: Open
 element.toolbar.copy-id: Copy ID
-element.toolbar.copy-full-path-to-clipboard: Copy Full Path
-element.toolbar.copy-deep-link-to-clipboard: Copy Deep link
+element.toolbar.copy-full-path-to-clipboard: Copy full path
+element.toolbar.copy-deep-link-to-clipboard: Copy deep link
 element.toolbar.show-full-info: Full info
 element.toolbar.copy-className: Class {{className}} - Copy
 element.unpublish: Unpublish
 element.publish: Publish
 element.locate-in-tree: Locate in Tree
-element.sidebar.filter.only-direct-children: only direct children
-element.sidebar.filter.only-unreferenced: only unreferenced
+element.sidebar.filter.only-direct-children: Only direct children
+element.sidebar.filter.only-unreferenced: Only unreferenced
 element.sidebar.field-filters: Field Filters
 element.full-information: Full information
 system-information.id: ID
@@ -1298,8 +1298,8 @@ folder: Folder
 archive: Archive
 audio: Audio
 image: Image
-image-gallery.clear-image-selection: Clear Image Selection
-image-gallery.delete-frame: Delete Frame
+image-gallery.clear-image-selection: Clear image selection
+image-gallery.delete-frame: Delete frame
 text: Text
 video: Video
 object: Object
@@ -1330,7 +1330,7 @@ tree.actions.clone: Clone
 tree.actions.copy: Copy
 tree.actions.paste: Paste
 tree.actions.delete: Delete
-tree.actions.add-user: Add User
+tree.actions.add-user: Add user
 tree.actions.clone-user: Clone user
 tree.actions.remove-user: Delete user
 tree.actions.folder: Folder
@@ -1340,17 +1340,17 @@ tree.actions.add-tag: New Tag
 tree.actions.delete-tag: Delete
 tree.actions.rename-tag: Rename
 tree.actions.role: Role
-tree.actions.add-role: Add Role
+tree.actions.add-role: Add role
 tree.actions.clone-role: Clone role
 tree.actions.remove-role: Delete role
-tree.actions.remove-folder: Remove Folder
+tree.actions.remove-folder: Remove folder
 tag-configuration.new: New
 tag-configuration.new-tag: New Tag
 tag-configuration.name: Name
 tag-configuration.parent-tag: Parent Tag
 tag-configuration.create: Create
 tag-configuration.save: Save
-tag-configuration.rename: Rename Tag
+tag-configuration.rename: Rename tag
 tag-configuration.successful-add: Tag has been added successfully
 tag-configuration.successful-update: Tag has been updated successfully
 tag-configuration.successful-deletion: Tag has been deleted successfully
@@ -1497,9 +1497,9 @@ user-management.roles: Roles
 user-management.role: Role
 user-management.users: Users
 user-management.user: User
-user-management.add-folder: Add new Folder
+user-management.add-folder: Add new folder
 user-management.add-folder.label: Enter the name of the new folder
-user-management.add-user: Add new User
+user-management.add-user: Add new user
 user-management.add-user.label: Enter the name of the new user
 user-management.last-login: Last Login
 user-management.search.id: ID
@@ -1517,9 +1517,9 @@ roles.add-folder.success: Folder added successfully
 roles.general: General
 roles.settings.title: Settings
 roles.workspaces.title: Workspaces
-roles.add-folder: Add new Folder
+roles.add-folder: Add new folder
 roles.add-folder.label: Enter the name of the new folder
-roles.add-role: Add new Role
+roles.add-role: Add new role
 roles.add-role.label: Enter the name of the new role
 roles.search.id: ID
 navigation.quick-access: Quick Access
@@ -1681,7 +1681,7 @@ image-thumbnails.editor.format: Format
 image-thumbnails.editor.format-required: Format is required
 image-thumbnails.editor.format-placeholder: Select a format...
 image-thumbnails.editor.format-auto: Auto (Web-optimized - recommended)
-image-thumbnails.delete.confirm: Do you really want to delete the Thumbnail
+image-thumbnails.delete.confirm: Do you really want to delete the thumbnail
 image-thumbnails.add.content: Enter the name of the new thumbnail (a-zA-Z0-9_-)
 image-thumbnails.add.validation.message: The thumbnail name is invalid
 image-thumbnails.editor.advanced: Advanced
@@ -1697,7 +1697,7 @@ image-thumbnails.editor.preserve-metadata: Preserve Meta Data
 image-thumbnails.editor.preserve-metadata.tooltip: "Preserve meta data (don't strip) (Imagick, ORIGINAL)\n('Preserve meta data' and 'preserve color' only works for transitions without compositions (frame, background color, ...) and color modifications (greyscale, sepia, ...))"
 image-thumbnails.editor.rasterize-svg: Rasterize SVGs
 image-thumbnails.editor.rasterize-svg.tooltip: "Rasterize SVGs (Imagick)\n(SVGs get automatically rasterized when a transformation other than resize or scale by width/height is used.)"
-image-thumbnails.editor.use-cropbox: Use Cropbox
+image-thumbnails.editor.use-cropbox: Use cropbox
 image-thumbnails.editor.use-cropbox.tooltip: "Use Cropbox (Ghostscript)\n(Sets the page size to the CropBox rather than the MediaBox, useful to exclude some margins and non-content areas.)"
 image-thumbnails.editor.downloadable: Downloadable
 image-thumbnails.editor.downloadable.tooltip: List as option in download section on image detail view
@@ -1728,7 +1728,7 @@ image-thumbnails.transformations.groups.main: Transformations
 image-thumbnails.transformations.groups.effects: Effects
 
 # Media Query Translations
-image-thumbnails.media-queries.add-transformation: Add Transformation
+image-thumbnails.media-queries.add-transformation: Add transformation
 
 # Cover Transformation
 image-thumbnails.transformations.cover.title: Configure Cover
@@ -1767,18 +1767,18 @@ image-thumbnails.transformations.scale-by-width.width: Width
 image-thumbnails.transformations.scale-by-width.force-resize: Force Resize
 
 # Resize Transformation
-image-thumbnails.transformations.resize.config-title: Configure Resize
+image-thumbnails.transformations.resize.config-title: Configure resize
 image-thumbnails.transformations.resize.width: Width
 image-thumbnails.transformations.resize.height: Height
 
 # Scale by Height Transformation
-image-thumbnails.transformations.scale-by-height.config-title: Configure Scale by Height
+image-thumbnails.transformations.scale-by-height.config-title: Configure scale by height
 image-thumbnails.transformations.scale-by-height.height: Height
 image-thumbnails.transformations.scale-by-height.height-placeholder: Enter height in pixels
 image-thumbnails.transformations.scale-by-height.force-resize: Force Resize
 
 # Trim Transformation
-image-thumbnails.transformations.trim.config-title: Configure Trim
+image-thumbnails.transformations.trim.config-title: Configure trim
 image-thumbnails.transformations.trim.trim-option: Trim Option
 image-thumbnails.transformations.trim.trim-option-placeholder: Select trim option
 image-thumbnails.transformations.trim.disabled: Disabled
@@ -1787,7 +1787,7 @@ image-thumbnails.transformations.trim.right: Right
 image-thumbnails.transformations.trim.both: Both
 
 # Effects Transformation
-image-thumbnails.transformations.effects.config-title: Configure Effect
+image-thumbnails.transformations.effects.config-title: Configure effect
 image-thumbnails.transformations.effects.effect-type: Effect Type
 image-thumbnails.transformations.effects.effect-type-placeholder: Select effect type
 image-thumbnails.transformations.effects.sepia: Sepia
@@ -1797,8 +1797,8 @@ image-thumbnails.transformations.effects.intensity: Intensity
 
 # Transformation tool strip
 image-thumbnails.transformations.add: Add transformation
-image-thumbnails.transformations.move-up: Move Up
-image-thumbnails.transformations.move-down: Move Down
+image-thumbnails.transformations.move-up: Move up
+image-thumbnails.transformations.move-down: Move down
 image-thumbnails.transformations.remove: Remove
 
 # Unknown/Fallback Transformation
@@ -1828,17 +1828,17 @@ video-thumbnails.editor.media-segments.add.bitrate-hint: Please enter a valid bi
 video-thumbnails.editor.media-segments.add.ok: Create
 video-thumbnails.editor.media-segments.default: Default
 video-thumbnails.editor.transformations.empty: No transformations have been selected
-video-thumbnails.delete.confirm: Do you really want to delete the Thumbnail
+video-thumbnails.delete.confirm: Do you really want to delete the thumbnail
 video-thumbnails.add.content: Enter the name of the new thumbnail (a-zA-Z0-9_-)
 video-thumbnails.add.validation.message: The thumbnail name is invalid
 
 # Video Transformation tool strip
-video-thumbnails.transformations.move-up: Move Up
-video-thumbnails.transformations.move-down: Move Down
+video-thumbnails.transformations.move-up: Move up
+video-thumbnails.transformations.move-down: Move down
 video-thumbnails.transformations.remove: Remove
 
 # Resize Transformation
-video-thumbnails.transformations.resize.config-title: Configure Resize
+video-thumbnails.transformations.resize.config-title: Configure resize
 video-thumbnails.transformations.resize.width: Width
 video-thumbnails.transformations.resize.width-placeholder: Enter width in pixels
 video-thumbnails.transformations.resize.height: Height
@@ -1846,29 +1846,29 @@ video-thumbnails.transformations.resize.height-placeholder: Enter height in pixe
 video-thumbnails.transformations.resize.even-number-hint: Width and height must be an even number
 
 # Scale by Width Transformation
-video-thumbnails.transformations.scale-by-width.config-title: Configure Scale by Width
+video-thumbnails.transformations.scale-by-width.config-title: Configure scale by width
 video-thumbnails.transformations.scale-by-width.width: Width
 video-thumbnails.transformations.scale-by-width.width-placeholder: Enter width in pixels
 
 # Scale by Height Transformation
-video-thumbnails.transformations.scale-by-height.config-title: Configure Scale by Height
+video-thumbnails.transformations.scale-by-height.config-title: Configure scale by height
 video-thumbnails.transformations.scale-by-height.height: Height
 video-thumbnails.transformations.scale-by-height.height-placeholder: Enter height in pixels
 
 # Cut Transformation
-video-thumbnails.transformations.cut.config-title: Configure Cut
+video-thumbnails.transformations.cut.config-title: Configure cut
 video-thumbnails.transformations.cut.start: Start
 video-thumbnails.transformations.cut.start-placeholder: "00:00:00.000"
 video-thumbnails.transformations.cut.duration: Duration
 video-thumbnails.transformations.cut.duration-placeholder: "00:00:10.000"
 
 # Set Framerate Transformation
-video-thumbnails.transformations.set-framerate.config-title: Configure Set Framerate
+video-thumbnails.transformations.set-framerate.config-title: Configure set framerate
 video-thumbnails.transformations.set-framerate.fps: FPS
 video-thumbnails.transformations.set-framerate.fps-placeholder: "25"
 
 # Color Channel Mixer Transformation
-video-thumbnails.transformations.color-channel-mixer.config-title: Configure Color Channel Mixer
+video-thumbnails.transformations.color-channel-mixer.config-title: Configure color channel mixer
 video-thumbnails.transformations.color-channel-mixer.effect: Effect
 video-thumbnails.transformations.color-channel-mixer.effect-placeholder: Select an effect
 video-thumbnails.transformations.color-channel-mixer.grayscale: Grayscale
@@ -1910,7 +1910,7 @@ image.add.and.dnd: Add or drop an image directly here
 image.upload.add.and.dnd: Upload, add or drop an image directly here
 image.too-small: The selected image is too small to be used here. Please use a bigger image.
 fallback: Fallback
-url-slug.add-site: Add Site
+url-slug.add-site: Add site
 url-slug.invalid: Please enter a valid URL slug (starting with a '/')
 site-id: Site ID
 deleted: deleted
@@ -1935,7 +1935,7 @@ reverse-object-relation.owner-hint: The current object is not the owner of these
 reverse-object-relation.owner-class: Owner class
 reverse-object-relation.owner-field: Owner field
 link.not-set: not set
-link.edit-title: Edit Link
+link.edit-title: Edit link
 link.tab.basic: Basic
 link.tab.advanced: Advanced
 link.text: Text
@@ -1951,8 +1951,8 @@ link.tabindex: Tabindex
 link.class: Class
 link.attributes: Attributes
 crop: Crop
-crop.remove: Remove Crop
-hotspots-markers-modal.edit-button: Add & Edit data
+crop.remove: Remove crop
+hotspots-markers-modal.edit-button: Add & edit data
 hotspots-markers-data-modal.title: Add & Edit data
 hotspots-markers-data-modal.new-data: New
 hotspots-markers-data-modal.apply: Apply
@@ -2045,7 +2045,7 @@ element: Element
 entries: entries
 entry: entry
 error_element_validation_failed: Validation failed
-element.delete.deleting-folder: Deleting Folder
+element.delete.deleting-folder: Deleting folder
 component.pagination.showing-items: Showing {{total}}
 edit-modal.inline-edit: Inline edit
 edit-modal.apply-changes: Apply changes
@@ -2093,7 +2093,7 @@ reports.editor.general-settings.group-label: Name an existing group or create ne
 reports.editor.general-settings.group-tooltip: You have to use the exact same name as the existing menu label. If the name is different or new - a new group will be created.
 reports.editor.general-settings.report-class-label: Report Class
 reports.editor.general-settings.group-icon-class-label: Group Icon Class
-reports.editor.general-settings.shortcut-menu-label: Create Shortcut in Menu
+reports.editor.general-settings.shortcut-menu-label: Create shortcut in menu
 reports.editor.source-definition.title: Source Definition
 reports.editor.source-definition.no-content: No available fields yet. Start by adding a field.
 reports.editor.source-definition.select-source-definition: Select a source definition
@@ -2122,14 +2122,14 @@ reports.editor.manage-column-configuration.display-type.hide: Hide
 reports.editor.manage-column-configuration.filter-drilldown: Filter Drilldown
 reports.editor.manage-column-configuration.filter-drilldown.empty: Empty
 reports.editor.manage-column-configuration.filter-drilldown.only-filter: Only Filter
-reports.editor.manage-column-configuration.filter-drilldown.filter-and-show: Filter and Show
+reports.editor.manage-column-configuration.filter-drilldown.filter-and-show: Filter and show
 reports.editor.manage-column-configuration.width: Width
 reports.editor.manage-column-configuration.label: Label
 reports.editor.manage-column-configuration.action: Action
 reports.editor.manage-column-configuration.action.none: None
-reports.editor.manage-column-configuration.action.open-document: Open Document
-reports.editor.manage-column-configuration.action.open-asset: Open Asset
-reports.editor.manage-column-configuration.action.open-object: Open Object
+reports.editor.manage-column-configuration.action.open-document: Open document
+reports.editor.manage-column-configuration.action.open-asset: Open asset
+reports.editor.manage-column-configuration.action.open-object: Open object
 reports.editor.manage-column-configuration.action.open-url: Open URL
 reports.editor.chart-settings.title: Chart Settings
 reports.editor.chart-settings.chart-type: Chart Type
@@ -2166,15 +2166,15 @@ widget.email-log.tab.parameters: Parameters
 widget.email-log.grid.name: Name
 widget.email-log.grid.value: Value
 email-log.subject: Subject
-email-log.tooltip.resend: Resend Email
-email-log.tooltip.forward: Forward Email
-email-log.tooltip.delete: Delete Email
+email-log.tooltip.resend: Resend email
+email-log.tooltip.forward: Forward email
+email-log.tooltip.delete: Delete email
 email-log.resend.email.success: Email has been resent successfully
-email-log.resend.confirmation.title: Resend Email
+email-log.resend.confirmation.title: Resend email
 email-log.resend.confirmation.text: Please confirm that you want to send the email again to all recipients.
-email-log.resend.confirmation.ok: Resend Email
+email-log.resend.confirmation.ok: Resend email
 email-log.forward.email.success: Email has been forwarded successfully
-email-log.forward.label: Forward Email
+email-log.forward.label: Forward email
 email-log.send.label: Send
 email-log.forward.email-address.label: Email Address
 email-log.delete.email.success: Email has been deleted successfully
@@ -2212,7 +2212,7 @@ application-logger.columns.component: Component
 application-logger.columns.source: Source
 application-logger.columns.details: Details
 application-logger.columns.type: Type
-application-logger.sidebar.search-parameter: Search Parameter
+application-logger.sidebar.search-parameter: Search parameter
 application-logger.detail-modal.title: Detail information
 application-logger.filter.date-from: From
 application-logger.filter.date-to: To
@@ -2247,11 +2247,11 @@ embed.loading: Loading...
 embed.iframe-title: Embedded content
 invalid-iframe: The entered iframe URL is invalid
 document.open-in-new-window: Open in new window
-document.open-preview-in-new-window: Open Preview in new window
+document.open-preview-in-new-window: Open preview in new window
 document.translation.title: Translation
-document.translation.open-translation: Open Translation
-document.translation.link-existing-document: Link existing Document
-document.translation.unlink-existing-document: Unlink existing Document
+document.translation.open-translation: Open translation
+document.translation.link-existing-document: Link existing document
+document.translation.unlink-existing-document: Unlink existing document
 document.translation.all-translations: All Translations
 document.translation.new-document: New Document
 document.translation.use-inheritance: Using inheritance
@@ -2293,9 +2293,9 @@ ownership-management.reassign-owner.placeholder: Search for a user by name
 ownership-management.delete.title: Delete configurations
 ownership-management.delete.content: "Are you sure you want to delete {{count}} configuration(s)?"
 component.search.pleaceholder: Search
-focal-point.set: Set Focal Point
+focal-point.set: Set focal point
 video.placeholder: Click to add a video
-video.add-video: Add Video
+video.add-video: Add video
 video.preview-in-progress: Video preview is being generated…
 date.placeholder: Select a date
 numeric.placeholder: Enter a number
@@ -2315,15 +2315,15 @@ test-email.form.title: Title
 test-email.form.message: Message
 test-email.form.document: Document
 test-email.form.parameters: Parameters
-test-email.form.parameters.add-parameter: Add Parameter
-test-email-modal-title: Send a Test-Email
+test-email.form.parameters.add-parameter: Add parameter
+test-email-modal-title: Send a test email
 test-email-modal-send: Send
 test-email.contentType.document: Document
 test-email.contentType.html: HTML
 test-email.contentType.text: Text
 test-email.parameters.columns.key: Key
 test-email.parameters.columns.value: Value
-test-email.parameters.add: Add Parameter
+test-email.parameters.add: Add parameter
 test-email.send.error: An error occurred while sending the test email
 test-email.success.modal.title: Sent Test-Email
 test-email.success.modal.text: Your test-email has been sent. Would you like to keep this window open to send the email again?
@@ -2351,16 +2351,16 @@ perspective-editor.form.general.icon: Icon
 perspective-editor.form.general.widget-configuration: Widget areas
 perspective-editor.form.main-nav-permission.title: Allowed main navigation actions
 perspective-editor.form.main-nav-permission.category.quickAccess: Quick Access
-perspective-editor.form.main-nav-permission.quickAccess.hidden: Hide Quick Access Menu
-perspective-editor.form.main-nav-permission.quickAccess.open_asset: Open Asset
-perspective-editor.form.main-nav-permission.quickAccess.open_document: Open Document
-perspective-editor.form.main-nav-permission.quickAccess.open_object: Open Object
+perspective-editor.form.main-nav-permission.quickAccess.hidden: Hide quick access menu
+perspective-editor.form.main-nav-permission.quickAccess.open_asset: Open asset
+perspective-editor.form.main-nav-permission.quickAccess.open_document: Open document
+perspective-editor.form.main-nav-permission.quickAccess.open_object: Open object
 perspective-editor.form.main-nav-permission.quickAccess.recycle_bin: Recycle Bin
 perspective-editor.form.main-nav-permission.category.dataManagement: Data Management
-perspective-editor.form.main-nav-permission.dataManagement.hidden: Hide Data Management Menu
+perspective-editor.form.main-nav-permission.dataManagement.hidden: Hide data management menu
 perspective-editor.form.main-nav-permission.dataManagement.notesEvents: Notes & Events
 perspective-editor.form.main-nav-permission.dataManagement.gdprDataExtractor: GDPR Data Extractor
-perspective-editor.form.main-nav-permission.dataManagement.searchReplaceAssignments: Search & Replace Assignments
+perspective-editor.form.main-nav-permission.dataManagement.searchReplaceAssignments: Search & replace assignments
 perspective-editor.form.main-nav-permission.dataManagement.predefinedProperties: Predefined Properties
 perspective-editor.form.main-nav-permission.dataManagement.tagConfiguration: Tag Configuration
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_bulkExport: Data Model Definition > Bulk Export
@@ -2368,29 +2368,29 @@ perspective-editor.form.main-nav-permission.dataManagement.dataModel_bulkImport:
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_classes: Data Model Definition > Classes
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_classificationStore: Data Model Definition > Classification Store
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_fieldCollections: Data Model Definition > Field Collections
-perspective-editor.form.main-nav-permission.dataManagement.dataModel_hidden: Hide Data Model Definition Menu
+perspective-editor.form.main-nav-permission.dataManagement.dataModel_hidden: Hide data model definition menu
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_objectBricks: Data Model Definition > Object Bricks
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_quantityValue: Data Model Definition > Quantity Value
 perspective-editor.form.main-nav-permission.dataManagement.dataModel_selectOptions: Data Model Definition > Select Options
 perspective-editor.form.main-nav-permission.category.experienceEcommerce: Experience & E-commerce
-perspective-editor.form.main-nav-permission.experienceEcommerce.hidden: Hide Experience & E-commerce Menu
+perspective-editor.form.main-nav-permission.experienceEcommerce.hidden: Hide experience & e-commerce menu
 perspective-editor.form.main-nav-permission.experienceEcommerce.emails: E-Mails
 perspective-editor.form.main-nav-permission.experienceEcommerce.documentTypes: Document Types
 perspective-editor.form.main-nav-permission.experienceEcommerce.websiteSettings: Website Settings
 perspective-editor.form.main-nav-permission.experienceEcommerce.redirects: Redirects
 perspective-editor.form.main-nav-permission.experienceEcommerce.robotsTxt: robots.txt
 perspective-editor.form.main-nav-permission.category.assetManagement: Asset Management
-perspective-editor.form.main-nav-permission.assetManagement.hidden: Hide Asset Management Menu
+perspective-editor.form.main-nav-permission.assetManagement.hidden: Hide asset management menu
 perspective-editor.form.main-nav-permission.assetManagement.assetThumbnails: Image Thumbnails
 perspective-editor.form.main-nav-permission.assetManagement.videoThumbnails: Video Thumbnails
 perspective-editor.form.main-nav-permission.assetManagement.predefinedAssetMetadata: Predefined Asset Metadata
 perspective-editor.form.main-nav-permission.category.translations: Translations
-perspective-editor.form.main-nav-permission.translations.hidden: Hide Translations Menu
+perspective-editor.form.main-nav-permission.translations.hidden: Hide translations menu
 perspective-editor.form.main-nav-permission.translations.translations: Translations
 perspective-editor.form.main-nav-permission.category.system: System
-perspective-editor.form.main-nav-permission.system.hidden: Hide System Menu
+perspective-editor.form.main-nav-permission.system.hidden: Hide system menu
 perspective-editor.form.main-nav-permission.system.applicationLogger: Application Logger
-perspective-editor.form.main-nav-permission.system.users_hidden: Hide Users/Roles Menu
+perspective-editor.form.main-nav-permission.system.users_hidden: Hide users/roles menu
 perspective-editor.form.main-nav-permission.system.users_roles: Roles
 perspective-editor.form.main-nav-permission.system.users_users: Users
 perspective-editor.form.main-nav-permission.system.appearanceBranding: Appearance & Branding
@@ -2402,16 +2402,16 @@ perspective-editor.form.main-nav-permission.system.cache_clearData: Cache > Data
 perspective-editor.form.main-nav-permission.system.cache_clearOutput: Cache > Clear Full Page Cache
 perspective-editor.form.main-nav-permission.system.cache_clearSymfony: Cache > Clean Symfony Cache
 perspective-editor.form.main-nav-permission.system.cache_clearTemp: Cache > Clear temporary files
-perspective-editor.form.main-nav-permission.system.cache_hidden: Hide Cache Menu
+perspective-editor.form.main-nav-permission.system.cache_hidden: Hide cache menu
 perspective-editor.form.main-nav-permission.system.systemSettings: System Settings
 perspective-editor.form.main-nav-permission.system.ownershipManagement: Ownership Management
 perspective-editor.form.main-nav-permission.system.about: About
 perspective-editor.form.main-nav-permission.category.reporting: Reporting
-perspective-editor.form.main-nav-permission.reporting.hidden: Hide Reporting Menu
+perspective-editor.form.main-nav-permission.reporting.hidden: Hide reporting menu
 perspective-editor.form.main-nav-permission.reporting.reports: Reports
 perspective-editor.form.main-nav-permission.reporting.customReportsConfiguration: Custom Reports Configuration
 perspective-editor.form.main-nav-permission.category.search: Search
-perspective-editor.form.main-nav-permission.search.hidden: Hide Search Menu
+perspective-editor.form.main-nav-permission.search.hidden: Hide search menu
 perspective-editor.create.success: Perspective created successfully
 perspective-editor.delete.success: Perspective deleted successfully
 perspective-editor.system-widgets.trees: Trees
@@ -2419,7 +2419,7 @@ perspective-editor.system-widgets.left: Left widgets
 perspective-editor.system-widgets.bottom: Bottom widgets
 perspective-editor.system-widgets.right: Right widgets
 perspective-editor.update.success: Perspective updated successfully
-widget-editor.create-modal.create: Create Widget
+widget-editor.create-modal.create: Create widget
 widget-editor.create-form.name: Name
 widget-editor.create-form.name.required: Please enter a valid name
 widget-editor.create-form.widgetType: Widget Type
@@ -2432,11 +2432,11 @@ widget-editor.update.success: Widget updated successfully
 widget-editor.widget-form.general.title: General
 widget-editor.widget-form.general.name: Name
 widget-editor.widget-form.general.icon: Icon
-widget-editor.widget-form.general.icon.select: Select Icon
+widget-editor.widget-form.general.icon.select: Select icon
 widget-editor.widget-form.specific.title: Specific
 widget-editor.widget-form.specific.element-type: Element Type
 widget-editor.widget-form.specific.root-folder: Root Folder
-widget-editor.widget-form.specific.show-root: Show Root
+widget-editor.widget-form.specific.show-root: Show root
 widget-editor.widget-form.specific.page-size: Page Size
 widget-editor.widget-form.allowed-objects.title: Allowed Objects (per default everything is allowed)
 widget-editor.widget-form.filters.title: Filters
@@ -2504,7 +2504,7 @@ no-languages-found: No languages found
 pretty-url: Pretty URL / URL Slug
 pretty-url-override-notice: (overrides path from tree-structure)
 content-main-document: Content-Main Document
-content-main-document.apply: Apply Content-Main Document
+content-main-document.apply: Apply content-main document
 content-main-document.apply-warning-title: Are you sure?
 content-main-document.apply-warning-message: All content will be lost
 never: never
@@ -2533,11 +2533,11 @@ user-management.permissions.quantityValueUnits: Quantity Value Units
 user-management.permissions.recyclebin: Recycle Bin
 user-management.permissions.redirects: Redirects
 user-management.permissions.seemode: Seemode
-user-management.permissions.selectoptions: Select Options
+user-management.permissions.selectoptions: Select options
 user-management.permissions.share_configurations: Share Configurations
 user-management.permissions.objects: Objects
 user-management.permissions.objectbricks: Objectbricks
-user-management.permissions.notifications_send: Send Notifications
+user-management.permissions.notifications_send: Send notifications
 user-management.permissions.notifications: Notifications
 user-management.permissions.predefined_properties: Predefined Properties
 user-management.permissions.perspective_editor: Perspective Editor
@@ -2545,15 +2545,15 @@ user-management.permissions.perspective_editor_view_edit: Perspective Editor Vie
 user-management.permissions.qr_codes: QR-Codes
 user-management.permissions.plugins: Plugins
 user-management.permissions.notes_events: Notes & Events
-user-management.permissions.clear_cache: Clear Cache
+user-management.permissions.clear_cache: Clear cache
 user-management.permissions.classificationstore: Classification Store
 user-management.permissions.classes: Classes
 user-management.permissions.workflow_details: Workflow Details
 user-management.permissions.users: Users
 user-management.permissions.website_settings: Website Settings
 user-management.permissions.asset_metadata: Asset Metadata
-user-management.permissions.clear_fullpage_cache: Clear Fullpage Cache
-user-management.permissions.clear_temp_files: Clear Temporary Files
+user-management.permissions.clear_fullpage_cache: Clear fullpage cache
+user-management.permissions.clear_temp_files: Clear temporary files
 user-management.permissions.system_settings: System Settings
 user-management.permissions.tags_assignment: Tags Assignment
 user-management.permissions.tags_configuration: Tags Configuration
@@ -2594,8 +2594,8 @@ user-management.permissions.pcp_configuration_permission: Pimcore Copilot Config
 user-management.permissions.pcp_job_run_permission: Job Run Overview
 user-management.permissions.pcp_job_runs_see_all_permission: See All Job Runs
 user-management.permissions.permission_workflow_designer: Activate Workflow Designer
-user-management.permissions.permission_workflow_designer_place_permissions: Allow Place Permissions Configuration
-user-management.permissions.permission_workflow_designer_trans_notifications: Allow Transition Notifications Configuration
+user-management.permissions.permission_workflow_designer_place_permissions: Allow place permissions configuration
+user-management.permissions.permission_workflow_designer_trans_notifications: Allow transition notifications configuration
 user-management.permissions.plugin_cmf_perm_activityview: CMF Activity View
 user-management.permissions.plugin_cmf_perm_customer_automation_rules: CMF Customer Automation Rules
 user-management.permissions.plugin_cmf_perm_customerview: CMF Customer View
@@ -2621,7 +2621,7 @@ user-management.permissions.studio_perspective_widget_editor: Perspective Widget
 user-management.permissions.wai_configuration_permission: Automation Blueprints Configuration
 forgot-password-form.username: Enter your username and Pimcore will send a login link to your email address
 forgot-password-form.username.placeholder: Username
-forgot-password-form.reset-password: Reset Password
+forgot-password-form.reset-password: Reset password
 forgot-password-form.success-message: A temporary login link has been sent to your email address. Please check your mailbox.
 forgot-password-form.back: Back to login
 subscription-details.community-edition: Learn more about Pimcore Editions
@@ -2637,7 +2637,7 @@ custom-language.default: Default
 login-token-modal.title: Login as this user in a different browser
 login-token-modal.description: The following link is a temporary link that allows you to login as this user in a different browser
 login-token-modal.close: Close
-login-token-modal.copy-and-close: Copy & Close
+login-token-modal.copy-and-close: Copy & close
 navigation.gdpr-extractor: GDPR Data Extractor
 widget.gdpr-extractor: GDPR Data Extractor
 gdpr-extractor.title: GDPR Data Extractor
@@ -2650,23 +2650,23 @@ gdpr-extractor.data-objects.table.field.type: Type
 gdpr-extractor.data-objects.table.field.id: ID
 gdpr-extractor.data-objects.table.field.fullPath: Path
 gdpr-extractor.data-objects.table.field.className: Class
-gdpr-extractor.data-objects.table.actions.export: Export DataObject Data
-gdpr-extractor.data-objects.table.actions.open: Open DataObject
-gdpr-extractor.data-objects.table.actions.delete: Delete DataObject
+gdpr-extractor.data-objects.table.actions.export: Export data object data
+gdpr-extractor.data-objects.table.actions.open: Open data object
+gdpr-extractor.data-objects.table.actions.delete: Delete data object
 gdpr-extractor.assets.table.field.type: Type
 gdpr-extractor.assets.table.field.id: ID
 gdpr-extractor.assets.table.field.fullPath: Full Path
 gdpr-extractor.assets.table.field.subType: Type
-gdpr-extractor.assets.table.actions.export: Export Asset Data
-gdpr-extractor.assets.table.actions.open: Open Asset
-gdpr-extractor.assets.table.actions.delete: Delete Asset
+gdpr-extractor.assets.table.actions.export: Export asset data
+gdpr-extractor.assets.table.actions.open: Open asset
+gdpr-extractor.assets.table.actions.delete: Delete asset
 gdpr-extractor.users.table.field.id: ID
 gdpr-extractor.users.table.field.name: Username
 gdpr-extractor.users.table.field.firstname: First Name
 gdpr-extractor.users.table.field.lastname: Last Name
 gdpr-extractor.users.table.field.email: Email
-gdpr-extractor.users.table.actions.export: Export User Data
-gdpr-extractor.users.table.actions.delete: Delete User
+gdpr-extractor.users.table.actions.export: Export user data
+gdpr-extractor.users.table.actions.delete: Delete user
 gdpr-extractor.table.field.actions: Actions
 gdpr-extractor.emails.table.field.sentDate: Sent Date
 gdpr-extractor.emails.table.field.from: From
@@ -2674,8 +2674,8 @@ gdpr-extractor.emails.table.field.to: To
 gdpr-extractor.emails.table.field.cc: CC
 gdpr-extractor.emails.table.field.bcc: BCC
 gdpr-extractor.emails.table.field.subject: Subject
-gdpr-extractor.emails.table.actions.export: Export Email Data
-gdpr-extractor.emails.table.actions.parameters: Expand Parameters
+gdpr-extractor.emails.table.actions.export: Export email data
+gdpr-extractor.emails.table.actions.parameters: Expand parameters
 gdpr-extractor.emails.table.actions.html: View HTML
 navigation.systemSettings: System Settings
 widget.system-settings: System Settings
@@ -2686,7 +2686,7 @@ system-settings.form.debug.field.enable-debug: Debug Admin-Translations (wrapped
 system-settings.form.debug.field.email-addresses: Debug Email Addresses
 system-settings.form.debug.field.email-addresses.placeholder: Enter email and press Enter...
 system-settings.collapse.localization: Localization & Internationalization (l10n/i18n)
-system-settings.form.localization.field.add-language: Add Language
+system-settings.form.localization.field.add-language: Add language
 system-settings.form.localization.field.fallback-language: Fallback Languages
 system-settings.form.localization.field.fallback-language-placeholder: Add fallback languages
 system-settings.form.localization.field.default-language: Default language
@@ -2753,22 +2753,22 @@ quantity-values.columns.factor: Conversion Factor
 quantity-values.columns.conversion-offset: Conversion Offset
 quantity-values.columns.converter: Converter Service
 quantity-values.columns.actions: Actions
-quantity-values.create-modal.title: Create Quantity Value Unit
+quantity-values.create-modal.title: Create quantity value unit
 quantity-values.create-modal.id-label: Unique identifier
 quantity-values.create-modal.id-placeholder: e.g. km, kg, ...
 quantity-values.create-modal.id-required: Unique identifier is required
 quantity-values.create-modal.create: Create
 quantity-values.export: Export
 quantity-values.import: Import
-quantity-values.import-modal.title: Import Quantity Value Units
+quantity-values.import-modal.title: Import quantity value units
 quantity-values.search: Search
 owner: Owner
 reverse-object-relation.tooltip: Non owner objects represent relations to an other object just in the same way as objects do. The difference is, that a non-owner object field is not the owner of the relation data, it is merely a view on data stored in other objects. Please choose the owner and field name where the data is originally stored.
 disabled-fields: Disabled fields
 allowed-targets: Allowed Targets
 bulk-export.title: Bulk Export
-bulk-export.select-all: Select All
-bulk-export.deselect-all: Deselect All
+bulk-export.select-all: Select all
+bulk-export.deselect-all: Deselect all
 bulk-export.export: Export
 bulk-export.cancel: Cancel
 bulk-export.type.class: Classes
@@ -2780,11 +2780,11 @@ bulk-import.cancel: Cancel
 bulk-import.next: Next
 bulk-import.back: Back
 bulk-import.import: Import
-bulk-import.job-title: Bulk Import
-bulk-import.browse-files: Browse Files
+bulk-import.job-title: Bulk import
+bulk-import.browse-files: Browse files
 bulk-import.remove-file: Remove
-bulk-import.select-all: Select All
-bulk-import.deselect-all: Deselect All
+bulk-import.select-all: Select all
+bulk-import.deselect-all: Deselect all
 bulk-import.type.class: Classes
 bulk-import.type.customlayout: Custom Layouts
 bulk-import.type.fieldcollection: Field Collections
@@ -2812,7 +2812,7 @@ translations.import.delta.column.key: Key
 translations.import.delta.column.locale: Locale
 translations.import.delta.column.current: Current Translation
 translations.import.delta.column.imported: Imported Translation
-translations.toolbar.import-merge: Import & Merge CSV
+translations.toolbar.import-merge: Import & merge CSV
 translations.import.delta.skip: Skip
 translations.import.delta.apply: Apply Selected ({{count}})
 widget.translation-merger: Merge Translations

--- a/translations/studio.es.yaml
+++ b/translations/studio.es.yaml
@@ -1236,8 +1236,8 @@ element.toolbar.copy-className: Clase {{className}} - Copiar
 element.unpublish: Despublicar
 element.publish: Publicar
 element.locate-in-tree: Localizar en el árbol
-element.sidebar.filter.only-direct-children: solo hijos directos
-element.sidebar.filter.only-unreferenced: solo sin referencias
+element.sidebar.filter.only-direct-children: Solo hijos directos
+element.sidebar.filter.only-unreferenced: Solo sin referencias
 element.sidebar.field-filters: Filtros de campo
 element.full-information: Información completa
 system-information.id: ID

--- a/translations/studio.es.yaml
+++ b/translations/studio.es.yaml
@@ -206,7 +206,7 @@ class-definition.general-settings.icon: Icono
 class-definition.general-settings.parent-class: Clase padre
 class-definition.general-settings.implements-interfaces: Implementa interfaces
 class-definition.general-settings.listing-parent-class: Clase padre de listado
-class-definition.general-settings.use-traits: Usar Traits
+class-definition.general-settings.use-traits: Usar traits
 class-definition.general-settings.listing-use-traits: Traits de listado
 class-definition.general-settings.link-generator-reference: Referencia del generador de enlaces
 class-definition.general-settings.preview-generator-reference: Referencia del generador de vista previa
@@ -280,7 +280,7 @@ select-option.validation.enter-id: Introduzca un ID
 select-option.validation.id-format: El nombre debe comenzar con una letra mayúscula, seguida de caracteres alfanuméricos
 select-option.general-settings.title: General
 select-option.general-settings.enum-name: Nombre de enumeración
-select-option.general-settings.use-traits: Usar Traits
+select-option.general-settings.use-traits: Usar traits
 select-option.general-settings.implements-interfaces: Implementa interfaces
 select-option.general-settings.group: Grupo
 select-option.general-settings.admin-only: Solo administrador
@@ -2504,7 +2504,7 @@ no-languages-found: No se encontraron idiomas
 pretty-url: Pretty URL / URL Slug
 pretty-url-override-notice: (sobrescribe la ruta de la estructura del árbol)
 content-main-document: Documento Content-Main
-content-main-document.apply: Aplicar documento Content-Main
+content-main-document.apply: Aplicar documento content-main
 content-main-document.apply-warning-title: ¿Está seguro?
 content-main-document.apply-warning-message: Se perderá todo el contenido
 never: nunca

--- a/translations/studio.fr.yaml
+++ b/translations/studio.fr.yaml
@@ -1236,8 +1236,8 @@ element.toolbar.copy-className: Classe {{className}} - Copier
 element.unpublish: Dépublier
 element.publish: Publier
 element.locate-in-tree: Localiser dans l'arborescence
-element.sidebar.filter.only-direct-children: uniquement les enfants directs
-element.sidebar.filter.only-unreferenced: uniquement les non référencés
+element.sidebar.filter.only-direct-children: Uniquement les enfants directs
+element.sidebar.filter.only-unreferenced: Uniquement les non référencés
 element.sidebar.field-filters: Filtres de champs
 element.full-information: Informations complètes
 system-information.id: ID

--- a/translations/studio.it.yaml
+++ b/translations/studio.it.yaml
@@ -1236,8 +1236,8 @@ element.toolbar.copy-className: Classe {{className}} - Copia
 element.unpublish: Annulla pubblicazione
 element.publish: Pubblica
 element.locate-in-tree: Individua nell'albero
-element.sidebar.filter.only-direct-children: solo figli diretti
-element.sidebar.filter.only-unreferenced: solo non referenziati
+element.sidebar.filter.only-direct-children: Solo figli diretti
+element.sidebar.filter.only-unreferenced: Solo non referenziati
 element.sidebar.field-filters: Filtri campo
 element.full-information: Informazioni complete
 system-information.id: ID

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -1236,8 +1236,8 @@ element.toolbar.copy-className: Klasse {{className}} – Kopier
 element.unpublish: Avpubliser
 element.publish: Publiser
 element.locate-in-tree: Finn i treet
-element.sidebar.filter.only-direct-children: kun direkte underelementer
-element.sidebar.filter.only-unreferenced: kun elementer uten referanser
+element.sidebar.filter.only-direct-children: Kun direkte underelementer
+element.sidebar.filter.only-unreferenced: Kun elementer uten referanser
 element.sidebar.field-filters: Feltfiltre
 element.full-information: Full informasjon
 system-information.id: ID

--- a/translations/studio.no.yaml
+++ b/translations/studio.no.yaml
@@ -206,8 +206,8 @@ class-definition.general-settings.icon: Ikon
 class-definition.general-settings.parent-class: Overordnet klasse
 class-definition.general-settings.implements-interfaces: Implementerer grensesnitt
 class-definition.general-settings.listing-parent-class: Overordnet klasse for oppføring
-class-definition.general-settings.use-traits: Bruk Traits
-class-definition.general-settings.listing-use-traits: Oppføring – Bruk Traits
+class-definition.general-settings.use-traits: Bruk traits
+class-definition.general-settings.listing-use-traits: Oppføring – bruk traits
 class-definition.general-settings.link-generator-reference: Link Generator-referanse
 class-definition.general-settings.preview-generator-reference: Preview Generator-referanse
 class-definition.general-settings.allow-inherit: Tillat arv
@@ -280,7 +280,7 @@ select-option.validation.enter-id: Vennligst oppgi en ID
 select-option.validation.id-format: Navnet må begynne med stor bokstav, etterfulgt av alfanumeriske tegn
 select-option.general-settings.title: Generelt
 select-option.general-settings.enum-name: Enum-navn
-select-option.general-settings.use-traits: Bruk Traits
+select-option.general-settings.use-traits: Bruk traits
 select-option.general-settings.implements-interfaces: Implementerer grensesnitt
 select-option.general-settings.group: Gruppe
 select-option.general-settings.admin-only: Kun administrator
@@ -1778,7 +1778,7 @@ image-thumbnails.transformations.scale-by-height.height-placeholder: Oppgi høyd
 image-thumbnails.transformations.scale-by-height.force-resize: Tving endring av størrelse
 
 # Trim-transformasjon
-image-thumbnails.transformations.trim.config-title: Konfigurer Trim
+image-thumbnails.transformations.trim.config-title: Konfigurer trim
 image-thumbnails.transformations.trim.trim-option: Trim-alternativ
 image-thumbnails.transformations.trim.trim-option-placeholder: Velg trim-alternativ
 image-thumbnails.transformations.trim.disabled: Deaktivert

--- a/translations/studio.sv.yaml
+++ b/translations/studio.sv.yaml
@@ -206,8 +206,8 @@ class-definition.general-settings.icon: Ikon
 class-definition.general-settings.parent-class: Föräldraklass
 class-definition.general-settings.implements-interfaces: Implementerar gränssnitt
 class-definition.general-settings.listing-parent-class: Listföräldraklass
-class-definition.general-settings.use-traits: Använd Traits
-class-definition.general-settings.listing-use-traits: Listning Använd Traits
+class-definition.general-settings.use-traits: Använd traits
+class-definition.general-settings.listing-use-traits: Listning använd traits
 class-definition.general-settings.link-generator-reference: Länkgeneratorreferens
 class-definition.general-settings.preview-generator-reference: Förhandsvisningsgeneratorreferens
 class-definition.general-settings.allow-inherit: Tillåt arv
@@ -280,7 +280,7 @@ select-option.validation.enter-id: Ange ett ID
 select-option.validation.id-format: Namnet måste börja med en stor bokstav, följt av alfanumeriska tecken
 select-option.general-settings.title: Allmänt
 select-option.general-settings.enum-name: Enum-namn
-select-option.general-settings.use-traits: Använd Traits
+select-option.general-settings.use-traits: Använd traits
 select-option.general-settings.implements-interfaces: Implementerar gränssnitt
 select-option.general-settings.group: Grupp
 select-option.general-settings.admin-only: Bara admin
@@ -1772,13 +1772,13 @@ image-thumbnails.transformations.resize.width: Bredd
 image-thumbnails.transformations.resize.height: Höjd
 
 # Skala efter höjd-transformation
-image-thumbnails.transformations.scale-by-height.config-title: Konfigurera Skala efter höjd
+image-thumbnails.transformations.scale-by-height.config-title: Konfigurera skala efter höjd
 image-thumbnails.transformations.scale-by-height.height: Höjd
 image-thumbnails.transformations.scale-by-height.height-placeholder: Ange höjd i pixlar
 image-thumbnails.transformations.scale-by-height.force-resize: Tvinga storleksändring
 
 # Trimma-transformation
-image-thumbnails.transformations.trim.config-title: Konfigurera Trimma
+image-thumbnails.transformations.trim.config-title: Konfigurera trimma
 image-thumbnails.transformations.trim.trim-option: Trimma-alternativ
 image-thumbnails.transformations.trim.trim-option-placeholder: Välj trimma-alternativ
 image-thumbnails.transformations.trim.disabled: Inaktiverad
@@ -1846,29 +1846,29 @@ video-thumbnails.transformations.resize.height-placeholder: Ange höjd i pixlar
 video-thumbnails.transformations.resize.even-number-hint: Bredd och höjd måste vara jämna tal
 
 # Skala efter bredd-transformation
-video-thumbnails.transformations.scale-by-width.config-title: Konfigurera Skala efter bredd
+video-thumbnails.transformations.scale-by-width.config-title: Konfigurera skala efter bredd
 video-thumbnails.transformations.scale-by-width.width: Bredd
 video-thumbnails.transformations.scale-by-width.width-placeholder: Ange bredd i pixlar
 
 # Skala efter höjd-transformation
-video-thumbnails.transformations.scale-by-height.config-title: Konfigurera Skala efter höjd
+video-thumbnails.transformations.scale-by-height.config-title: Konfigurera skala efter höjd
 video-thumbnails.transformations.scale-by-height.height: Höjd
 video-thumbnails.transformations.scale-by-height.height-placeholder: Ange höjd i pixlar
 
 # Klipp-transformation
-video-thumbnails.transformations.cut.config-title: Konfigurera Klipp
+video-thumbnails.transformations.cut.config-title: Konfigurera klipp
 video-thumbnails.transformations.cut.start: Start
 video-thumbnails.transformations.cut.start-placeholder: "00:00:00.000"
 video-thumbnails.transformations.cut.duration: Längd
 video-thumbnails.transformations.cut.duration-placeholder: "00:00:10.000"
 
 # Ställ in bildfrekvens-transformation
-video-thumbnails.transformations.set-framerate.config-title: Konfigurera Bildfrekvens
+video-thumbnails.transformations.set-framerate.config-title: Konfigurera bildfrekvens
 video-thumbnails.transformations.set-framerate.fps: FPS
 video-thumbnails.transformations.set-framerate.fps-placeholder: "25"
 
 # Färgkanalmixer-transformation
-video-thumbnails.transformations.color-channel-mixer.config-title: Konfigurera Färgkanalmixer
+video-thumbnails.transformations.color-channel-mixer.config-title: Konfigurera färgkanalmixer
 video-thumbnails.transformations.color-channel-mixer.effect: Effekt
 video-thumbnails.transformations.color-channel-mixer.effect-placeholder: Välj en effekt
 video-thumbnails.transformations.color-channel-mixer.grayscale: Gråskala
@@ -2504,7 +2504,7 @@ no-languages-found: Inga språk hittades
 pretty-url: Snygg URL / URL Slug
 pretty-url-override-notice: (åsidosätter sökväg från trädstruktur)
 content-main-document: Content-Main-dokument
-content-main-document.apply: Tillämpa Content-Main-dokument
+content-main-document.apply: Tillämpa content-main-dokument
 content-main-document.apply-warning-title: Är du säker?
 content-main-document.apply-warning-message: Allt innehåll kommer att förloras
 never: aldrig

--- a/translations/studio.sv.yaml
+++ b/translations/studio.sv.yaml
@@ -168,7 +168,7 @@ folder.folder-editor-tabs.preview: Förhandsvisning
 folder.folder-editor-tabs.view: Lista
 toolbar.reload.confirmation: Är du säker på att du vill ladda om den här fliken? Alla osparade ändringar kommer att förloras.
 toolbar.reload: Ladda om
-toolbar.save-and-publish: Spara & Publicera
+toolbar.save-and-publish: Spara & publicera
 toolbar.save: Spara
 toolbar.save-draft: Spara utkast
 toolbar.more: Mer
@@ -1236,8 +1236,8 @@ element.toolbar.copy-className: Klass {{className}} - Kopiera
 element.unpublish: Avpublicera
 element.publish: Publicera
 element.locate-in-tree: Hitta i träd
-element.sidebar.filter.only-direct-children: bara direkta barn
-element.sidebar.filter.only-unreferenced: bara utan referenser
+element.sidebar.filter.only-direct-children: Bara direkta barn
+element.sidebar.filter.only-unreferenced: Bara utan referenser
 element.sidebar.field-filters: Fältfilter
 element.full-information: Fullständig information
 system-information.id: ID


### PR DESCRIPTION
Resolves: https://github.com/pimcore/studio-ui-bundle/issues/1778

What was done
Applied the Studio UI writing style convention consistently across all 7 translation files. The rule: Sentence case for buttons, modal titles, and interactive elements (only first word capitalized); Title Case for navigation items, tab titles, and context menus (each principal word capitalized).

English file — 163 changes
Buttons/actions (Title Case → Sentence case):

Dialog buttons: "Save and Continue" → "Save and continue", "Discard and Continue" → "Discard and continue", "Discard Changes" → "Discard changes"
Primary actions: "Save & Publish" → "Save & publish", "Save & Apply" → "Save & apply", "Add & Edit" → "Add & edit", "Copy & Close" → "Copy & close"
Open buttons: "Open Data Object" / "Open Asset" / "Open Document" → lowercase
Email log actions: "Resend Email" / "Forward Email" / "Delete Email" → lowercase across tooltip, button, and confirmation keys
Bulk operations: "Select All" / "Deselect All" → lowercase (×4, export + import)
Site actions: "Remove Site" / "Edit Site" / "Use as Site" → lowercase
Tree actions: "Add User" / "Add Role" / "Remove Folder" / "Rename Tag" → lowercase
Image gallery: "Delete Frame" / "Clear Image Selection" → lowercase
Toolbar: "Copy Full Path" / "Copy Deep link" → "Copy full path" / "Copy deep link"
Import/Export: "Import Class Definition" / "Export Class Definition" → lowercase
Various: "Convert Document", "Reset Password", "Browse Files", "Add Video", "Set Focal Point", "Edit Link", "Remove Crop", etc.
Modal/dialog titles (Title Case → Sentence case):

"Unsaved Changes" → "Unsaved changes"
"Open Data Object" / "Open Asset" / "Open Document" → lowercase
"Missing Context" → "Missing context"
"Create Quantity Value Unit" / "Import Quantity Value Units" → lowercase
"Resend Email" → "Resend email"
"Batch Edit" → "Batch edit" (modal title + job title)
"Bulk Import" → "Bulk import"
"Send a Test-Email" → "Send a test email"
"Create New X" buttons → Sentence case:

"Create New Class Definition" → "Create new class definition"
"Create New Field Collection" → "Create new field collection"
"Create New Object Brick" → "Create new object brick"
"Create New Select Option" → "Create new select option"
"Create New Custom Layout" → "Create new custom layout"
"Add new X" — fixed internal noun capitalization:

"Add new Folder" → "Add new folder" (×2, user management + roles)
"Add new User" → "Add new user"
"Add new Role" → "Add new role"
"Add new Object of type {{className}}" → "Add new object of type {{className}}"
"Add new Variant of type {{className}}" → "Add new variant of type {{className}}"
Checkboxes/toggles → Sentence case:

"Show Variants" / "Show App Logger Tab" / "Show Field Lookup" → lowercase
"Enable Grid Locking" / "Encrypt Data" → lowercase
"Use Traits" → "Use traits" (×2, class-definition + select-option)
"Use Cropbox" → "Use cropbox"
"Allow Inheritance" / "Allow Variants" → lowercase
"Admin Only" → "Admin only"
"Advanced Mode" → "Advanced mode"
"Show Root" → "Show root"
"Hide Empty Data" / "Hide Locale Labels When Tabs Reached" → lowercase
"Listing Use Traits" → "Listing use traits"
Perspective editor permission toggles (15 items):

"Hide Quick Access Menu" → "Hide quick access menu"
"Hide Data Management Menu" / "Hide Data Model Definition Menu" → lowercase
"Hide Experience & E-commerce Menu" / "Hide Asset Management Menu" → lowercase
"Hide Translations Menu" / "Hide System Menu" / "Hide Users/Roles Menu" → lowercase
"Hide Cache Menu" / "Hide Reporting Menu" / "Hide Search Menu" → lowercase
"Open Asset" / "Open Document" / "Open Object" → lowercase
"Search & Replace Assignments" → "Search & replace assignments"
User management permission labels (7 items):

"Select Options" / "Send Notifications" → lowercase
"Clear Cache" / "Clear Fullpage Cache" / "Clear Temporary Files" → lowercase
"Allow Place Permissions Configuration" / "Allow Transition Notifications Configuration" → lowercase
Config panel titles (10 items):

"Configure Resize" / "Configure Scale by Height" / "Configure Trim" / "Configure Effect" → lowercase (image thumbnails)
"Configure Resize" / "Configure Scale by Width" / "Configure Scale by Height" / "Configure Cut" / "Configure Set Framerate" / "Configure Color Channel Mixer" → lowercase (video thumbnails)
GDPR action buttons (10 items):

"Export DataObject Data" → "Export data object data"
"Open DataObject" → "Open data object"
"Delete DataObject" → "Delete data object"
Same pattern for Asset, User, Email actions
"Expand Parameters" → "Expand parameters"
Report column config (4 items):

"Open Document" / "Open Asset" / "Open Object" → lowercase
"Filter and Show" → "Filter and show"
"Create Shortcut in Menu" → "Create shortcut in menu"
Misc actions:

"Move Up" / "Move Down" → lowercase (×6 across select-option, image-thumbnails, video-thumbnails)
"Delete Template" / "Preview Item" → lowercase
"Import & Merge CSV" → "Import & merge CSV"
"Apply Content-Main Document" → "Apply content-main document"
"Create Widget" / "Select Icon" / "Select Image Preview" → lowercase
"Upload Path" / "Abort Job" / "Clear Unpublished" → lowercase
"Open in New Window" → "Open in new window"
"Add Transformation" / "Add Site" / "Add Language" / "Add Parameter" (×2) → lowercase
"Search Parameter" → "Search parameter"
"Select Item Configuration" / "Select Options" (×2) → lowercase
Mixed case inconsistencies fixed:

"Copy Deep link" → "Copy deep link"
"Open Preview in new window" → "Open preview in new window"
"Link existing Document" → "Link existing document"
"Unlink existing Document" → "Unlink existing document"
"Select language for New Document" → "Select language for new document"
All-lowercase filter labels → first letter capitalized:

"only direct children" → "Only direct children"
"only unreferenced" → "Only unreferenced"
Confirmation text fix:

"Do you really want to delete the Thumbnail" → "...the thumbnail" (×2, image + video)
Non-English files — 11 changes
French (2): "uniquement les enfants directs" → "Uniquement…", "uniquement les non référencés" → "Uniquement…"

Spanish (2): "solo hijos directos" → "Solo…", "solo sin referencias" → "Solo…"

Italian (2): "solo figli diretti" → "Solo…", "solo non referenziati" → "Solo…"

Norwegian (2): "kun direkte underelementer" → "Kun…", "kun elementer uten referanser" → "Kun…"

Swedish (3): Same two filter fixes + "Spara & Publicera" → "Spara & publicera"

German (0): No changes needed — German noun capitalization is grammatically correct.

What was deliberately NOT changed
Context menu items remain Title Case: New Page, New Snippet, New Email, New Link, New Hardlink, New Object, New Variant, New Folder, New Tag, New Asset(s), Upload Files, Upload Zip, Download as ZIP, Search & Move, Expand Children, Clear Thumbnails, Sort Children By, Copy ID, Close Tab/Others/All/Unmodified
Navigation menu items remain Title Case: Clear Cache, Clear Full Page Cache, Clear Temporary Files, Open Asset, Open Document, Open Data Object, Bulk Export, Bulk Import, etc.
Key binding descriptions remain Title Case (feature names)
Widget editor context menu config labels remain Title Case (describe context menu items)
Type/category labels remain Title Case: Custom Layouts, Field Collections, Object Bricks
Form field labels remain Title Case: Parent Class, PHP Class Name, Implements Interfaces, etc.
Acronyms preserved: CSV, HTML, URL, ZIP, JSON, ID, HTTP, GDPR
Proper nouns preserved: Excel